### PR TITLE
Add Badges to README

### DIFF
--- a/.github/workflows/valska-actions.yml
+++ b/.github/workflows/valska-actions.yml
@@ -1,7 +1,10 @@
-name: ValSKA CI/CD Pipeline
+name: CI Pipeline
 
 on: 
-  pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ValSKA-HERA-beam-FWHM
 
-[![CI/CD Pipeline](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/valska-actions.yml/badge.svg)](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/valska-actions.yml)
+[![CI Pipeline](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/valska-actions.yml/badge.svg)](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/valska-actions.yml)
 
 [![Docs Status](https://readthedocs.org/projects/ValSKA-HERA-beam-FWHM/badge/?version=latest)](https://ValSKA-HERA-beam-FWHM.readthedocs.io/)
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,9 @@
 # ValSKA-HERA-beam-FWHM
 
-<p align="center">
-  <a href="https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions">
-    <img src="https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/ci.yml/badge.svg" alt="CI">
-  </a>
-  <a href="https://ValSKA-HERA-beam-FWHM.readthedocs.io/">
-    <img src="https://readthedocs.org/projects/ValSKA-HERA-beam-FWHM/badge/?version=latest" alt="Docs">
-  </a>
-  <a href="https://codecov.io/gh/uksrc/ValSKA-HERA-beam-FWHM">
-    <img src="https://codecov.io/gh/uksrc/ValSKA-HERA-beam-FWHM/branch/main/graph/badge.svg" alt="Coverage">
-  </a>
-</p>
-
 [![CI/CD Pipeline](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/valska-actions.yml/badge.svg)](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/valska-actions.yml)
 
 [![Docs Status](https://readthedocs.org/projects/ValSKA-HERA-beam-FWHM/badge/?version=latest)](https://ValSKA-HERA-beam-FWHM.readthedocs.io/)
 
-[![codecov](https://codecov.io/gh/uksrc/ValSKA-HERA-beam-FWHM/branch/main/graph/badge.svg)](https://codecov.io/gh/uksrc/ValSKA-HERA-beam-FWHM)
-
-[![Coverage Status](https://coveralls.io/repos/github/uksrc/ValSKA-HERA-beam-FWHM/badge.svg)](https://coveralls.io/github/uksrc/ValSKA-HERA-beam-FWHM)
 
 **An open-source, reproducible, flexible, and extensible package for validating the sensitivity of 21-cm power-spectrum inference to imperfect knowledge of the interferometric primary-beam FWHM.**
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # ValSKA-HERA-beam-FWHM
 
+<p align="center">
+  <a href="https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions">
+    <img src="https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/ci.yml/badge.svg" alt="CI">
+  </a>
+  <a href="https://ValSKA-HERA-beam-FWHM.readthedocs.io/">
+    <img src="https://readthedocs.org/projects/ValSKA-HERA-beam-FWHM/badge/?version=latest" alt="Docs">
+  </a>
+  <a href="https://codecov.io/gh/uksrc/ValSKA-HERA-beam-FWHM">
+    <img src="https://codecov.io/gh/uksrc/ValSKA-HERA-beam-FWHM/branch/main/graph/badge.svg" alt="Coverage">
+  </a>
+</p>
+
+[![CI/CD Pipeline](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/valska-actions.yml/badge.svg)](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/actions/workflows/valska-actions.yml)
+
+[![Docs Status](https://readthedocs.org/projects/ValSKA-HERA-beam-FWHM/badge/?version=latest)](https://ValSKA-HERA-beam-FWHM.readthedocs.io/)
+
+[![codecov](https://codecov.io/gh/uksrc/ValSKA-HERA-beam-FWHM/branch/main/graph/badge.svg)](https://codecov.io/gh/uksrc/ValSKA-HERA-beam-FWHM)
+
+[![Coverage Status](https://coveralls.io/repos/github/uksrc/ValSKA-HERA-beam-FWHM/badge.svg)](https://coveralls.io/github/uksrc/ValSKA-HERA-beam-FWHM)
+
 **An open-source, reproducible, flexible, and extensible package for validating the sensitivity of 21-cm power-spectrum inference to imperfect knowledge of the interferometric primary-beam FWHM.**
 
 ---


### PR DESCRIPTION
# Description
The issue involves adding badges to the GitHub repository. These badges will indicate the status of the Continuous Integration (CI) pipeline and the documentation.

## Type of change
- New feature
- Documentation update

## Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (`make python-test`)
- [x] Notebooks tests pass locally (`make notebook-test`)
- [x] Linting/formatting checks pass locally (`make python-format`, `make python-lint`)
- [x] I have added or updated unit tests for my changes, where applicable
- [x] I have updated relevant documentation (README, docs, docstrings, examples), where applicable and checked that the new documentation has rendered correctly in ReadTheDocs
- [x] I have linked any related issues and requested appropriate reviewers
