### PR TITLE
Add colour output to CLI tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,8 @@ fallback_version = "0.1.0"
 
 [tool.ruff]
 extend-include = ["*.ipynb"]
+extend-exclude = ["src/valska_hera_beam/_version.py"]
+force-exclude = true
 
 [tool.ruff.lint]
 # E/F = Flake8, I = Isort, UP = Pyupgrade

--- a/src/valska_hera_beam/cli_format.py
+++ b/src/valska_hera_beam/cli_format.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Literal, TextIO
+from argparse import ArgumentParser
+from typing import Literal, TextIO, cast
 
 from rich.console import Console
 from rich.text import Text
 
 ColorMode = Literal["auto", "always", "never"]
+ProgressMode = Literal["auto", "always", "never"]
 
 _STYLES = {
     "bold_cyan": "bold cyan",
@@ -78,3 +80,55 @@ class CliColors:
 
     def warning(self, text: object) -> str:
         return self.style(text, "yellow")
+
+
+def add_color_argument(parser: ArgumentParser) -> None:
+    """Add the standard ValSKA color-mode option to a CLI parser."""
+    parser.add_argument(
+        "--color",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help=(
+            "Colorize human-readable terminal output. "
+            "Default: auto (enabled only for TTY output and disabled by NO_COLOR)."
+        ),
+    )
+
+
+def add_progress_argument(parser: ArgumentParser) -> None:
+    """Add the standard ValSKA progress-mode option to a CLI parser."""
+    parser.add_argument(
+        "--progress",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help=(
+            "Show Rich progress output for long-running CLI steps. "
+            "Default: auto (enabled only for interactive stderr)."
+        ),
+    )
+
+
+def resolve_color_mode(raw: object) -> ColorMode:
+    """Return a validated color mode from argparse output."""
+    if raw in ("auto", "always", "never"):
+        return cast(ColorMode, raw)
+    return "auto"
+
+
+def resolve_progress_mode(raw: object) -> ProgressMode:
+    """Return a validated progress mode from argparse output."""
+    if raw in ("auto", "always", "never"):
+        return cast(ProgressMode, raw)
+    return "auto"
+
+
+def show_progress(
+    mode: ProgressMode, *, json_out: bool, stream: TextIO | None = None
+) -> bool:
+    """Return whether progress output should be displayed."""
+    if json_out or mode == "never":
+        return False
+    if mode == "always":
+        return True
+    progress_stream = stream if stream is not None else sys.stderr
+    return bool(getattr(progress_stream, "isatty", lambda: False)())

--- a/src/valska_hera_beam/cli_format.py
+++ b/src/valska_hera_beam/cli_format.py
@@ -6,19 +6,21 @@ import os
 import sys
 from typing import Literal, TextIO
 
+from rich.console import Console
+from rich.text import Text
+
 ColorMode = Literal["auto", "always", "never"]
 
 _STYLES = {
-    "bold_cyan": "\033[1;36m",
-    "dim": "\033[2m",
-    "green": "\033[32m",
-    "yellow": "\033[33m",
+    "bold_cyan": "bold cyan",
+    "dim": "dim",
+    "green": "green",
+    "yellow": "yellow",
 }
-_RESET = "\033[0m"
 
 
 class CliColors:
-    """Apply ANSI styles when color is enabled for a terminal stream."""
+    """Apply Rich terminal styles when color is enabled for a stream."""
 
     def __init__(
         self,
@@ -30,6 +32,12 @@ class CliColors:
         self.mode = mode
         self.stream = stream if stream is not None else sys.stdout
         self.enabled = enabled and self._should_enable()
+        self.console = Console(
+            force_terminal=self.enabled,
+            color_system="standard" if self.enabled else None,
+            no_color=not self.enabled,
+            file=self.stream,
+        )
 
     def _should_enable(self) -> bool:
         if self.mode == "never":
@@ -44,10 +52,13 @@ class CliColors:
         value = str(text)
         if not self.enabled:
             return value
-        prefix = _STYLES.get(style_name)
-        if prefix is None:
+        rich_style = _STYLES.get(style_name)
+        if rich_style is None:
             return value
-        return f"{prefix}{value}{_RESET}"
+        styled = Text(value, style=rich_style)
+        with self.console.capture() as capture:
+            self.console.print(styled, end="")
+        return capture.get()
 
     def heading(self, text: object) -> str:
         return self.style(text, "bold_cyan")

--- a/src/valska_hera_beam/cli_format.py
+++ b/src/valska_hera_beam/cli_format.py
@@ -15,6 +15,7 @@ _STYLES = {
     "bold_cyan": "bold cyan",
     "dim": "dim",
     "green": "green",
+    "red": "red",
     "yellow": "yellow",
 }
 
@@ -71,6 +72,9 @@ class CliColors:
 
     def success(self, text: object) -> str:
         return self.style(text, "green")
+
+    def error(self, text: object) -> str:
+        return self.style(text, "red")
 
     def warning(self, text: object) -> str:
         return self.style(text, "yellow")

--- a/src/valska_hera_beam/cli_format.py
+++ b/src/valska_hera_beam/cli_format.py
@@ -1,0 +1,65 @@
+"""Small helpers for terminal-oriented CLI formatting."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Literal, TextIO
+
+ColorMode = Literal["auto", "always", "never"]
+
+_STYLES = {
+    "bold_cyan": "\033[1;36m",
+    "dim": "\033[2m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+}
+_RESET = "\033[0m"
+
+
+class CliColors:
+    """Apply ANSI styles when color is enabled for a terminal stream."""
+
+    def __init__(
+        self,
+        mode: ColorMode = "auto",
+        *,
+        stream: TextIO | None = None,
+        enabled: bool = True,
+    ) -> None:
+        self.mode = mode
+        self.stream = stream if stream is not None else sys.stdout
+        self.enabled = enabled and self._should_enable()
+
+    def _should_enable(self) -> bool:
+        if self.mode == "never":
+            return False
+        if os.environ.get("NO_COLOR") is not None:
+            return False
+        if self.mode == "always":
+            return True
+        return bool(getattr(self.stream, "isatty", lambda: False)())
+
+    def style(self, text: object, style_name: str) -> str:
+        value = str(text)
+        if not self.enabled:
+            return value
+        prefix = _STYLES.get(style_name)
+        if prefix is None:
+            return value
+        return f"{prefix}{value}{_RESET}"
+
+    def heading(self, text: object) -> str:
+        return self.style(text, "bold_cyan")
+
+    def path(self, text: object) -> str:
+        return self.style(text, "green")
+
+    def source(self, text: object) -> str:
+        return self.style(f"[{text}]", "dim")
+
+    def success(self, text: object) -> str:
+        return self.style(text, "green")
+
+    def warning(self, text: object) -> str:
+        return self.style(text, "yellow")

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_cleanup.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_cleanup.py
@@ -11,6 +11,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    resolve_color_mode,
+)
 from valska_hera_beam.utils import get_default_path_manager
 
 from .cli_list_sweeps import discover_sweeps
@@ -233,40 +238,58 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print machine-readable JSON payload.",
     )
+    add_color_argument(parser)
     return parser
 
 
-def _print_text(payload: dict[str, Any]) -> None:
+def _format_status(status: object, *, colors: CliColors) -> str:
+    text = str(status)
+    if text in ("planned", "moved", "deleted"):
+        return colors.success(text)
+    if text == "skipped":
+        return colors.warning(text)
+    if text == "error":
+        return colors.error(text)
+    return text
+
+
+def _print_text(payload: dict[str, Any], *, colors: CliColors) -> None:
     summary = payload["summary"]
-    print("Sweep cleanup summary:")
+    print(colors.heading("Sweep cleanup summary:"))
+    mode = "execute" if payload["execute"] else "dry-run"
     print(
-        f"  mode:              {'execute' if payload['execute'] else 'dry-run'}"
+        "  mode:              "
+        f"{colors.warning(mode) if payload['execute'] else colors.success(mode)}"
     )
-    print(f"  results_root:      {payload['results_root']}")
+    print(f"  results_root:      {colors.path(payload['results_root'])}")
     print(f"  sweeps_discovered: {summary['sweeps_discovered']}")
     print(f"  sweeps_targeted:   {summary['sweeps_targeted']}")
     print(f"  candidates_total:  {summary['candidates_total']}")
-    print(f"  planned:           {summary['planned_count']}")
-    print(f"  moved:             {summary['moved_count']}")
-    print(f"  deleted:           {summary['deleted_count']}")
-    print(f"  skipped:           {summary['skipped_count']}")
-    print(f"  errors:            {summary['error_count']}")
+    print(f"  planned:           {colors.success(summary['planned_count'])}")
+    print(f"  moved:             {colors.success(summary['moved_count'])}")
+    print(f"  deleted:           {colors.success(summary['deleted_count'])}")
+    print(f"  skipped:           {colors.warning(summary['skipped_count'])}")
+    print(f"  errors:            {colors.error(summary['error_count'])}")
 
     if payload.get("trash_root") is not None:
-        print(f"  trash_root:        {payload['trash_root']}")
+        print(f"  trash_root:        {colors.path(payload['trash_root'])}")
 
-    print("\nActions:")
+    print("\n" + colors.heading("Actions:"))
     if not payload["actions"]:
         print("  (none)")
         return
 
     for row in payload["actions"]:
-        line = f"  - {row['scope']}: {row['status']} -> {row['path']}"
+        line = (
+            f"  - {row['scope']}: "
+            f"{_format_status(row['status'], colors=colors)} "
+            f"-> {colors.path(row['path'])}"
+        )
         if row.get("target_path"):
-            line += f" -> {row['target_path']}"
+            line += f" -> {colors.path(row['target_path'])}"
         print(line)
         if row.get("reason"):
-            print(f"      reason: {row['reason']}")
+            print(f"      reason: {colors.warning(row['reason'])}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -532,7 +555,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.json_out:
         print(json.dumps(payload, indent=2))
     else:
-        _print_text(payload)
+        colors = CliColors(
+            resolve_color_mode(args.color), enabled=not bool(args.json_out)
+        )
+        _print_text(payload, colors=colors)
 
     if bool(args.fail_on_error) and errors > 0:
         return 1

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_compare_sweeps.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_compare_sweeps.py
@@ -11,6 +11,12 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    resolve_color_mode,
+)
+
 _Metric = (
     "delta_log_evidence",
     "log10_bayes_factor_signal_over_no_signal",
@@ -68,6 +74,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print machine-readable JSON payload.",
     )
+    add_color_argument(parser)
     return parser
 
 
@@ -222,31 +229,66 @@ def _build_payload(
     }
 
 
-def _print_text(payload: dict[str, Any]) -> None:
+def _format_delta(value: object, *, colors: CliColors) -> str:
+    if not isinstance(value, str | int | float):
+        return str(value)
+    delta = float(value)
+    text = f"{delta:+.6g}"
+    if delta == 0:
+        return text
+    return colors.warning(text)
+
+
+def _print_text(payload: dict[str, Any], *, colors: CliColors) -> None:
     summary = payload["summary"]
     left = payload["left"]
     right = payload["right"]
 
-    print("Sweep comparison summary:")
+    print(colors.heading("Sweep comparison summary:"))
     print(f"  metric:             {payload['metric']}")
-    print(f"  left:               {left['name']} ({left['summary_json']})")
-    print(f"  right:              {right['name']} ({right['summary_json']})")
+    print(
+        f"  left:               "
+        f"{left['name']} ({colors.path(left['summary_json'])})"
+    )
+    print(
+        f"  right:              "
+        f"{right['name']} ({colors.path(right['summary_json'])})"
+    )
     print(f"  left_points:        {summary['left_points']}")
     print(f"  right_points:       {summary['right_points']}")
     print(f"  shared_points:      {summary['shared_points']}")
     print(f"  compared_points:    {summary['compared_points']}")
-    print(f"  skipped_metric:     {summary['skipped_missing_metric']}")
-    print(f"  status_mismatch:    {summary['status_mismatch_points']}")
-    print(f"  left_only_points:   {summary['left_only_points']}")
-    print(f"  right_only_points:  {summary['right_only_points']}")
+    print(
+        "  skipped_metric:     "
+        f"{colors.warning(summary['skipped_missing_metric'])}"
+    )
+    print(
+        "  status_mismatch:    "
+        f"{colors.warning(summary['status_mismatch_points'])}"
+    )
+    print(
+        f"  left_only_points:   {colors.warning(summary['left_only_points'])}"
+    )
+    print(
+        f"  right_only_points:  {colors.warning(summary['right_only_points'])}"
+    )
 
     if summary["mean_delta"] is not None:
-        print(f"  mean_delta:         {summary['mean_delta']:+.6g}")
-        print(f"  min_delta:          {summary['min_delta']:+.6g}")
-        print(f"  max_delta:          {summary['max_delta']:+.6g}")
+        print(
+            "  mean_delta:         "
+            f"{_format_delta(summary['mean_delta'], colors=colors)}"
+        )
+        print(
+            "  min_delta:          "
+            f"{_format_delta(summary['min_delta'], colors=colors)}"
+        )
+        print(
+            "  max_delta:          "
+            f"{_format_delta(summary['max_delta'], colors=colors)}"
+        )
         print(f"  mean_abs_delta:     {summary['mean_abs_delta']:+.6g}")
 
-    print("\nTop differences (right - left):")
+    print("\n" + colors.heading("Top differences (right - left):"))
     rows = payload["top_differences"]
     if not rows:
         print("  (none)")
@@ -257,7 +299,7 @@ def _print_text(payload: dict[str, Any]) -> None:
                 f"{row['point_key']}: "
                 f"left={row['left_value']:+.6g}, "
                 f"right={row['right_value']:+.6g}, "
-                f"delta={row['delta']:+.6g}"
+                f"delta={_format_delta(row['delta'], colors=colors)}"
             )
 
 
@@ -283,7 +325,10 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2))
         return 0
 
-    _print_text(payload)
+    colors = CliColors(
+        resolve_color_mode(args.color), enabled=not bool(args.json_out)
+    )
+    _print_text(payload, colors=colors)
     return 0
 
 

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_list_sweeps.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_list_sweeps.py
@@ -9,6 +9,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    resolve_color_mode,
+)
 from valska_hera_beam.utils import get_default_path_manager
 
 
@@ -153,18 +158,21 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print machine-readable JSON payload.",
     )
+    add_color_argument(parser)
     return parser
 
 
-def _print_text(results_root: Path, entries: list[dict[str, Any]]) -> None:
-    print(f"Results root: {results_root}")
-    print("Sweep directories:")
+def _print_text(
+    results_root: Path, entries: list[dict[str, Any]], *, colors: CliColors
+) -> None:
+    print(f"{colors.heading('Results root:')} {colors.path(results_root)}")
+    print(colors.heading("Sweep directories:"))
     if not entries:
         print("  (none found)")
         return
 
     for item in entries:
-        print(f"  - {item['sweep_dir']}")
+        print(f"  - {colors.path(item['sweep_dir'])}")
         print(f"      run_id: {item.get('run_id')}")
         if item.get("beam_model") is not None:
             print(f"      beam: {item['beam_model']}")
@@ -214,7 +222,10 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2))
         return 0
 
-    _print_text(results_root, filtered)
+    colors = CliColors(
+        resolve_color_mode(args.color), enabled=not bool(args.json_out)
+    )
+    _print_text(results_root, filtered, colors=colors)
     return 0
 
 

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_report.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_report.py
@@ -7,18 +7,23 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import cast
 
 from rich import box
 from rich.table import Table
 
-from valska_hera_beam.cli_format import CliColors, ColorMode
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    add_progress_argument,
+    resolve_color_mode,
+    resolve_progress_mode,
+    show_progress,
+)
 from valska_hera_beam.external_tools.bayeseor.report import (
     SweepReportResult,
     generate_sweep_report,
 )
 
-_ProgressMode = str
 _TableStyle = str
 
 
@@ -98,33 +103,9 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print report result payload as JSON.",
     )
-    parser.add_argument(
-        "--progress",
-        choices=["auto", "always", "never"],
-        default="auto",
-        help=(
-            "Show Rich progress output for long-running report steps. "
-            "Default: auto (enabled only for interactive stderr)."
-        ),
-    )
-    parser.add_argument(
-        "--color",
-        choices=["auto", "always", "never"],
-        default="auto",
-        help=(
-            "Colorize human-readable terminal output. "
-            "Default: auto (enabled only for TTY output and disabled by NO_COLOR)."
-        ),
-    )
+    add_progress_argument(parser)
+    add_color_argument(parser)
     return parser
-
-
-def _show_progress(mode: _ProgressMode, *, json_out: bool) -> bool:
-    if json_out or mode == "never":
-        return False
-    if mode == "always":
-        return True
-    return bool(sys.stderr.isatty())
 
 
 def _format_perturbation_label(raw_label: object) -> str:
@@ -324,8 +305,9 @@ def main(argv: list[str] | None = None) -> int:
                 args.include_complete_analysis_table
                 or args.print_complete_analysis_table
             ),
-            show_progress=_show_progress(
-                str(args.progress), json_out=bool(args.json_out)
+            show_progress=show_progress(
+                resolve_progress_mode(args.progress),
+                json_out=bool(args.json_out),
             ),
         )
     except Exception as exc:
@@ -362,7 +344,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     colors = CliColors(
-        cast(ColorMode, args.color), enabled=not bool(args.json_out)
+        resolve_color_mode(args.color), enabled=not bool(args.json_out)
     )
     _print_summary(result, colors=colors)
     if args.print_complete_analysis_table:

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_report.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_report.py
@@ -13,6 +13,8 @@ from valska_hera_beam.external_tools.bayeseor.report import (
     generate_sweep_report,
 )
 
+_ProgressMode = str
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser for ``valska-bayeseor-report``."""
@@ -73,7 +75,24 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print report result payload as JSON.",
     )
+    parser.add_argument(
+        "--progress",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help=(
+            "Show Rich progress output for long-running report steps. "
+            "Default: auto (enabled only for interactive stderr)."
+        ),
+    )
     return parser
+
+
+def _show_progress(mode: _ProgressMode, *, json_out: bool) -> bool:
+    if json_out or mode == "never":
+        return False
+    if mode == "always":
+        return True
+    return bool(sys.stderr.isatty())
 
 
 def _print_summary(result: SweepReportResult) -> None:
@@ -112,6 +131,9 @@ def main(argv: list[str] | None = None) -> int:
             ),
             include_complete_analysis_table=bool(
                 args.include_complete_analysis_table
+            ),
+            show_progress=_show_progress(
+                str(args.progress), json_out=bool(args.json_out)
             ),
         )
     except Exception as exc:

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_report.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_report.py
@@ -7,13 +7,19 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import cast
 
+from rich import box
+from rich.table import Table
+
+from valska_hera_beam.cli_format import CliColors, ColorMode
 from valska_hera_beam.external_tools.bayeseor.report import (
     SweepReportResult,
     generate_sweep_report,
 )
 
 _ProgressMode = str
+_TableStyle = str
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -70,6 +76,23 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--print-complete-analysis-table",
+        action="store_true",
+        help=(
+            "Print a terminal summary table for complete-analysis results. "
+            "Implies --include-complete-analysis-table."
+        ),
+    )
+    parser.add_argument(
+        "--complete-analysis-table-style",
+        choices=["emoji", "plain"],
+        default="emoji",
+        help=(
+            "Terminal style for --print-complete-analysis-table. "
+            "Use 'plain' for ASCII-only validation labels. Default: emoji."
+        ),
+    )
+    parser.add_argument(
         "--json",
         dest="json_out",
         action="store_true",
@@ -84,6 +107,15 @@ def build_parser() -> argparse.ArgumentParser:
             "Default: auto (enabled only for interactive stderr)."
         ),
     )
+    parser.add_argument(
+        "--color",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help=(
+            "Colorize human-readable terminal output. "
+            "Default: auto (enabled only for TTY output and disabled by NO_COLOR)."
+        ),
+    )
     return parser
 
 
@@ -95,30 +127,189 @@ def _show_progress(mode: _ProgressMode, *, json_out: bool) -> bool:
     return bool(sys.stderr.isatty())
 
 
-def _print_summary(result: SweepReportResult) -> None:
-    print("\nSweep report generated:")
-    print(f"  sweep_dir:      {result.sweep_dir}")
-    print(f"  out_dir:        {result.out_dir}")
+def _format_perturbation_label(raw_label: object) -> str:
+    label = str(raw_label)
+    try:
+        frac = float(label.split("_", 1)[1])
+    except Exception:
+        return label
+
+    if label.startswith("antdiam_"):
+        return f"ΔD/D = {frac * 100:+.2f}%"
+    if label.startswith("fwhm_"):
+        return f"ΔFWHM/FWHM = {frac * 100:+.2f}%"
+    return f"Δ = {frac * 100:+.2f}%"
+
+
+def _perturbation_fraction(raw_label: object) -> float | None:
+    label = str(raw_label)
+    try:
+        return float(label.split("_", 1)[1])
+    except Exception:
+        return None
+
+
+def _coerce_float(raw: object) -> float:
+    if isinstance(raw, str | int | float):
+        return float(raw)
+    raise TypeError(f"Expected a numeric value, got {type(raw).__name__}")
+
+
+def _plain_interpretation(log_bayes_factor: object) -> str:
+    try:
+        log_bf = _coerce_float(log_bayes_factor)
+    except Exception:
+        return "Unable to evaluate"
+    if log_bf > 0:
+        return "Strong evidence for spurious power detected"
+    if log_bf < 0:
+        return "Unbiased inferences recovered"
+    return "Inconclusive"
+
+
+def _format_log_bayes_factor(raw: object) -> str:
+    try:
+        return f"{_coerce_float(raw):.3f}"
+    except Exception:
+        return "N/A"
+
+
+def _validation_display(validation: object, *, style: _TableStyle) -> str:
+    text = str(validation)
+    if style == "plain":
+        return text
+    if text == "PASS":
+        return "✅ PASS"
+    if text == "FAIL":
+        return "❌ FAIL"
+    return f"❌ {text}" if text else "❌ ERROR"
+
+
+def _validation_style(validation: object, *, colors: CliColors) -> str | None:
+    if not colors.enabled:
+        return None
+    text = str(validation)
+    if "PASS" in text:
+        return "green"
+    if "FAIL" in text or "ERROR" in text:
+        return "red"
+    return "yellow"
+
+
+def _print_complete_analysis_table(
+    rows: list[dict[str, object]], *, style: _TableStyle, colors: CliColors
+) -> None:
+    if not rows:
+        print("\nNo successful complete-analysis results to summarize.")
+        return
+
+    table_rows = [
+        {
+            "perturbation": _format_perturbation_label(
+                row.get("perturbation", "unknown")
+            ),
+            "log_bf": _format_log_bayes_factor(row.get("log_bayes_factor")),
+            "validation": _validation_display(
+                row.get("validation", "ERROR"), style=style
+            ),
+            "validation_style": _validation_style(
+                row.get("validation", "ERROR"), colors=colors
+            ),
+            "interpretation": _plain_interpretation(
+                row.get("log_bayes_factor")
+            ),
+            "sort_value": _perturbation_fraction(
+                row.get("perturbation", "unknown")
+            ),
+        }
+        for row in rows
+    ]
+    table_rows.sort(
+        key=lambda row: (
+            row["sort_value"] is None,
+            row["sort_value"] if isinstance(row["sort_value"], float) else 0.0,
+            str(row["perturbation"]),
+        )
+    )
+
+    table = Table(
+        title="Complete BayesEoR Perturbation Analysis Summary",
+        box=box.ASCII,
+        show_lines=False,
+    )
+    table.add_column("Perturbation", style="cyan" if colors.enabled else None)
+    table.add_column("Log BF", justify="right")
+    table.add_column("Validation")
+    table.add_column("Interpretation")
+
+    pass_count = 0
+    fail_count = 0
+    for row in table_rows:
+        validation = str(row["validation"])
+        if "PASS" in validation:
+            pass_count += 1
+        elif "FAIL" in validation:
+            fail_count += 1
+        table.add_row(
+            str(row["perturbation"]),
+            str(row["log_bf"]),
+            str(row["validation"]),
+            str(row["interpretation"]),
+            style=row["validation_style"]
+            if isinstance(row["validation_style"], str)
+            else None,
+        )
+
+    colors.console.print()
+    colors.console.print(table)
+    colors.console.print(
+        colors.success(
+            f"TOTAL: {len(table_rows)} | PASS: {pass_count} | "
+            f"FAIL: {fail_count} | ERROR: 0"
+        )
+    )
+
+
+def _print_summary(result: SweepReportResult, *, colors: CliColors) -> None:
+    print("\n" + colors.heading("Sweep report generated:"))
+    print(f"  sweep_dir:      {colors.path(result.sweep_dir)}")
+    print(f"  out_dir:        {colors.path(result.out_dir)}")
     print(f"  evidence_source:{result.evidence_source}")
     print(f"  points_total:   {result.rows_total}")
-    print(f"  points_complete:{result.rows_complete}")
-    print(f"  summary_csv:    {result.summary_csv}")
-    print(f"  summary_json:   {result.summary_json}")
+    print(f"  points_complete:{colors.success(result.rows_complete)}")
+    print(f"  summary_csv:    {colors.path(result.summary_csv)}")
+    print(f"  summary_json:   {colors.path(result.summary_json)}")
     if result.delta_plot_png is not None:
-        print(f"  delta_plot:     {result.delta_plot_png}")
+        print(f"  delta_plot:     {colors.path(result.delta_plot_png)}")
     if result.evidence_plot_png is not None:
-        print(f"  evidence_plot:  {result.evidence_plot_png}")
+        print(f"  evidence_plot:  {colors.path(result.evidence_plot_png)}")
     if result.plot_analysis_results_png is not None:
-        print(f"  plot_analysis_results: {result.plot_analysis_results_png}")
+        print(
+            "  plot_analysis_results: "
+            f"{colors.path(result.plot_analysis_results_png)}"
+        )
     if result.complete_analysis_json is not None:
-        print(f"  complete_analysis_json: {result.complete_analysis_json}")
+        print(
+            "  complete_analysis_json: "
+            f"{colors.path(result.complete_analysis_json)}"
+        )
     if result.complete_analysis_csv is not None:
-        print(f"  complete_analysis_csv:  {result.complete_analysis_csv}")
+        print(
+            "  complete_analysis_csv:  "
+            f"{colors.path(result.complete_analysis_csv)}"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint for ``valska-bayeseor-report``."""
     args = build_parser().parse_args(argv)
+
+    if args.json_out and args.print_complete_analysis_table:
+        print(
+            "ERROR: --print-complete-analysis-table cannot be combined with --json.",
+            file=sys.stderr,
+        )
+        return 2
 
     try:
         result = generate_sweep_report(
@@ -131,6 +322,7 @@ def main(argv: list[str] | None = None) -> int:
             ),
             include_complete_analysis_table=bool(
                 args.include_complete_analysis_table
+                or args.print_complete_analysis_table
             ),
             show_progress=_show_progress(
                 str(args.progress), json_out=bool(args.json_out)
@@ -164,14 +356,27 @@ def main(argv: list[str] | None = None) -> int:
             "complete_analysis_csv": str(result.complete_analysis_csv)
             if result.complete_analysis_csv is not None
             else None,
+            "complete_analysis_rows": result.complete_analysis_rows,
         }
         print(json.dumps(payload, indent=2))
         return 0
 
-    _print_summary(result)
+    colors = CliColors(
+        cast(ColorMode, args.color), enabled=not bool(args.json_out)
+    )
+    _print_summary(result, colors=colors)
+    if args.print_complete_analysis_table:
+        _print_complete_analysis_table(
+            result.complete_analysis_rows,
+            style=str(args.complete_analysis_table_style),
+            colors=colors,
+        )
     if result.rows_complete < result.rows_total:
         print(
-            "\nNote: some points were incomplete and are marked in the summary table."
+            "\n"
+            + colors.warning(
+                "Note: some points were incomplete and are marked in the summary table."
+            )
         )
     return 0
 

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_report_all.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_report_all.py
@@ -9,6 +9,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    add_progress_argument,
+    resolve_color_mode,
+    resolve_progress_mode,
+    show_progress,
+)
 from valska_hera_beam.utils import get_default_path_manager
 
 from .cli_list_sweeps import discover_sweeps
@@ -186,6 +194,8 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print machine-readable JSON output.",
     )
+    add_progress_argument(parser)
+    add_color_argument(parser)
     return parser
 
 
@@ -213,38 +223,51 @@ def _result_to_payload(result: SweepReportResult) -> dict[str, Any]:
         "complete_analysis_csv": str(result.complete_analysis_csv)
         if result.complete_analysis_csv is not None
         else None,
+        "complete_analysis_rows": result.complete_analysis_rows,
     }
 
 
-def _print_text(payload: dict[str, Any]) -> None:
+def _format_status(status: object, *, colors: CliColors) -> str:
+    text = str(status)
+    if text == "generated":
+        return colors.success(text)
+    if text == "skipped":
+        return colors.warning(text)
+    if text == "error":
+        return colors.error(text)
+    return text
+
+
+def _print_text(payload: dict[str, Any], *, colors: CliColors) -> None:
     summary = payload["summary"]
-    print("Sweep batch report summary:")
-    print(f"  results_root: {payload['results_root']}")
+    print(colors.heading("Sweep batch report summary:"))
+    print(f"  results_root: {colors.path(payload['results_root'])}")
     print(f"  discovered:   {summary['count_discovered']}")
     print(f"  targeted:     {summary['count_targeted']}")
-    print(f"  generated:    {summary['count_generated']}")
-    print(f"  skipped:      {summary['count_skipped']}")
-    print(f"  errors:       {summary['count_errors']}")
+    print(f"  generated:    {colors.success(summary['count_generated'])}")
+    print(f"  skipped:      {colors.warning(summary['count_skipped'])}")
+    print(f"  errors:       {colors.error(summary['count_errors'])}")
 
-    print("\nPer-sweep:")
+    print("\n" + colors.heading("Per-sweep:"))
     if not payload["sweeps"]:
         print("  (none)")
         return
 
     for row in payload["sweeps"]:
+        status = _format_status(row["status"], colors=colors)
         print(
             "  - "
             f"{row.get('run_id') or '(unknown)'} "
             f"[{row.get('beam_model')}/{row.get('sky_model')}] "
-            f"=> {row['status']}"
+            f"=> {status}"
         )
-        print(f"      dir: {row['sweep_dir']}")
+        print(f"      dir: {colors.path(row['sweep_dir'])}")
         if row.get("out_dir") is not None:
-            print(f"      out: {row['out_dir']}")
+            print(f"      out: {colors.path(row['out_dir'])}")
         if row.get("summary_json") is not None:
-            print(f"      summary_json: {row['summary_json']}")
+            print(f"      summary_json: {colors.path(row['summary_json'])}")
         if row.get("error") is not None:
-            print(f"      error: {row['error']}")
+            print(f"      error: {colors.error(row['error'])}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -328,6 +351,10 @@ def main(argv: list[str] | None = None) -> int:
                 include_complete_analysis_table=bool(
                     args.include_complete_analysis_table
                 ),
+                show_progress=show_progress(
+                    resolve_progress_mode(args.progress),
+                    json_out=bool(args.json_out),
+                ),
             )
             row["status"] = "generated"
             row["out_dir"] = str(result.out_dir)
@@ -373,7 +400,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.json_out:
         print(json.dumps(payload, indent=2))
     else:
-        _print_text(payload)
+        colors = CliColors(
+            resolve_color_mode(args.color), enabled=not bool(args.json_out)
+        )
+        _print_text(payload, colors=colors)
 
     if bool(args.fail_on_error) and errors > 0:
         return 1

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_resume.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_resume.py
@@ -9,6 +9,12 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    resolve_color_mode,
+)
+
 from .sweep_health import inspect_sweep_health, sweep_health_to_dict
 
 
@@ -50,6 +56,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print machine-readable JSON payload.",
     )
+    add_color_argument(parser)
     return parser
 
 
@@ -130,17 +137,28 @@ def _build_point_commands(
     return commands, notes, needs
 
 
-def _print_text(payload: dict[str, Any]) -> None:
+def _format_status(status: object, *, colors: CliColors) -> str:
+    text = str(status)
+    if text == "ok":
+        return colors.success(text)
+    if text == "partial":
+        return colors.warning(text)
+    if text in ("missing", "invalid", "error"):
+        return colors.error(text)
+    return text
+
+
+def _print_text(payload: dict[str, Any], *, colors: CliColors) -> None:
     summary = payload["summary"]
-    print("Sweep resume suggestions:")
-    print(f"  sweep_dir:       {payload['sweep_dir']}")
+    print(colors.heading("Sweep resume suggestions:"))
+    print(f"  sweep_dir:       {colors.path(payload['sweep_dir'])}")
     print(f"  stage:           {payload['stage']}")
     print(f"  hypothesis:      {payload['hypothesis']}")
     print(f"  points_total:    {summary['points_total']}")
-    print(f"  points_targeted: {summary['points_targeted']}")
-    print(f"  commands_total:  {summary['commands_total']}")
+    print(f"  points_targeted: {colors.warning(summary['points_targeted'])}")
+    print(f"  commands_total:  {colors.warning(summary['commands_total'])}")
 
-    print("\nPer-point commands:")
+    print("\n" + colors.heading("Per-point commands:"))
     rows = payload["points"]
     if not rows:
         print("  (none)")
@@ -151,11 +169,14 @@ def _print_text(payload: dict[str, Any]) -> None:
             "  - "
             f"{row['run_label']} ({row['perturb_parameter']}={row['perturb_frac']:+.3f})"
         )
-        print(f"      status: {row['point_status']}")
+        print(
+            f"      status: "
+            f"{_format_status(row['point_status'], colors=colors)}"
+        )
         for cmd in row["commands"]:
-            print(f"      {cmd}")
+            print(f"      {colors.success(cmd)}")
         for note in row["notes"]:
-            print(f"      note: {note}")
+            print(f"      note: {colors.warning(note)}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -206,7 +227,10 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2))
         return 0
 
-    _print_text(payload)
+    colors = CliColors(
+        resolve_color_mode(args.color), enabled=not bool(args.json_out)
+    )
+    _print_text(payload, colors=colors)
     return 0
 
 

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_sweep.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_sweep.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import Any, Literal
 
+from valska_hera_beam.cli_format import CliColors
 from valska_hera_beam.external_tools.bayeseor import (
     BayesEoRInstall,
     CondaRunner,
@@ -566,6 +567,15 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print the full sweep result object as JSON.",
     )
+    p.add_argument(
+        "--color",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help=(
+            "Colorize human-readable terminal output. "
+            "Default: auto (enabled only for TTY output and disabled by NO_COLOR)."
+        ),
+    )
 
     return p
 
@@ -774,28 +784,38 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if args.dry_run:
+        colors = CliColors(args.color, enabled=not bool(args.json_out))
         sd = sweep_root(results_root, beam_model, sky_model, args.run_id)
-        print("\n[DRY RUN] Sweep would be executed with:")
-        print(f"  results_root: {results_root} [{results_root_src}]")
-        print(f"  beam_model:   {beam_model} [{beam_sky_src}]")
-        print(f"  sky_model:    {sky_model} [{beam_sky_src}]")
+        print("\n" + colors.heading("[DRY RUN] Sweep would be executed with:"))
+        print(
+            f"  results_root: {colors.path(results_root)} "
+            f"{colors.source(results_root_src)}"
+        )
+        print(f"  beam_model:   {beam_model} {colors.source(beam_sky_src)}")
+        print(f"  sky_model:    {sky_model} {colors.source(beam_sky_src)}")
         print(f"  run_id:       {args.run_id}")
-        print(f"  sweep_dir:    {sd}")
-        print(f"  template:     {template_yaml} [{template_src}]")
-        print(f"  variant:      {variant} [{variant_src}]")
-        print(f"  data:         {data_resolved} [{data_src}]")
+        print(f"  sweep_dir:    {colors.path(sd)}")
+        print(
+            f"  template:     {colors.path(template_yaml)} "
+            f"{colors.source(template_src)}"
+        )
+        print(f"  variant:      {variant} {colors.source(variant_src)}")
+        print(
+            f"  data:         {colors.path(data_resolved)} "
+            f"{colors.source(data_src)}"
+        )
         print(f"  perturb_parameter:  {perturb_parameter}")
         if perturb_parameter == "fwhm_deg":
             print(
                 "  fwhm_fracs:   "
                 f"{fracs if fracs is not None else '(built-in default 9-point set)'} "
-                f"[{fracs_src}]"
+                f"{colors.source(fracs_src)}"
             )
         else:
             print(
                 "  antenna_diameter_fracs:   "
                 f"{fracs if fracs is not None else '(built-in default 9-point set)'} "
-                f"[{fracs_src}]"
+                f"{colors.source(fracs_src)}"
             )
         print(f"  unique:       {bool(args.unique)}")
         print(f"  submit:       {args.submit}")
@@ -810,7 +830,7 @@ def main(argv: list[str] | None = None) -> int:
         fracs_to_show = (
             fracs if fracs is not None else sweep_mod._default_fwhm_fracs()
         )
-        print("\n[DRY RUN] Points:")
+        print("\n" + colors.heading("[DRY RUN] Points:"))
         for frac in fracs_to_show:
             run_label = sweep_mod._format_run_label(
                 perturb_parameter=perturb_parameter, frac=float(frac)
@@ -824,9 +844,17 @@ def main(argv: list[str] | None = None) -> int:
                 run_label=run_label,
             )
             run_dir = base / "<UTCSTAMP>" if args.unique else base
-            print(f"  {float(frac):+0.3f}  {run_label}  ->  {run_dir}")
+            print(
+                f"  {float(frac):+0.3f}  {run_label}  ->  "
+                f"{colors.path(run_dir)}"
+            )
 
-        print("\n[DRY RUN] No files or jobs will be created/submitted.")
+        print(
+            "\n"
+            + colors.success(
+                "[DRY RUN] No files or jobs will be created/submitted."
+            )
+        )
         return 0
 
     install = BayesEoRInstall(repo_path=Path(str(repo_path)).expanduser())

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_sweep.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_sweep.py
@@ -8,7 +8,11 @@ import sys
 from pathlib import Path
 from typing import Any, Literal
 
-from valska_hera_beam.cli_format import CliColors
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    resolve_color_mode,
+)
 from valska_hera_beam.external_tools.bayeseor import (
     BayesEoRInstall,
     CondaRunner,
@@ -567,15 +571,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print the full sweep result object as JSON.",
     )
-    p.add_argument(
-        "--color",
-        choices=["auto", "always", "never"],
-        default="auto",
-        help=(
-            "Colorize human-readable terminal output. "
-            "Default: auto (enabled only for TTY output and disabled by NO_COLOR)."
-        ),
-    )
+    add_color_argument(p)
 
     return p
 
@@ -784,7 +780,9 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if args.dry_run:
-        colors = CliColors(args.color, enabled=not bool(args.json_out))
+        colors = CliColors(
+            resolve_color_mode(args.color), enabled=not bool(args.json_out)
+        )
         sd = sweep_root(results_root, beam_model, sky_model, args.run_id)
         print("\n" + colors.heading("[DRY RUN] Sweep would be executed with:"))
         print(

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_sweep_audit.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_sweep_audit.py
@@ -9,6 +9,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    resolve_color_mode,
+)
 from valska_hera_beam.utils import get_default_path_manager
 
 from .cli_list_sweeps import discover_sweeps
@@ -133,6 +138,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print machine-readable JSON output.",
     )
+    add_color_argument(parser)
     return parser
 
 
@@ -212,48 +218,72 @@ def _build_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _print_text(results_root: Path, rows: list[dict[str, Any]]) -> None:
+def _format_status(status: object, *, colors: CliColors) -> str:
+    text = str(status)
+    if text == "ok":
+        return colors.success(text)
+    if text == "partial":
+        return colors.warning(text)
+    if text in ("missing", "invalid", "error"):
+        return colors.error(text)
+    return text
+
+
+def _format_validation(exit_code: object, *, colors: CliColors) -> str:
+    text = str(exit_code)
+    return colors.success(text) if text == "0" else colors.error(text)
+
+
+def _print_text(
+    results_root: Path, rows: list[dict[str, Any]], *, colors: CliColors
+) -> None:
     summary = _build_summary(rows)
-    print("Sweep audit summary:")
-    print(f"  results_root: {results_root}")
+    print(colors.heading("Sweep audit summary:"))
+    print(f"  results_root: {colors.path(results_root)}")
     print(f"  sweeps:       {summary['count']}")
     print(
         "  status:       "
-        f"ok={summary['status_counts'].get('ok', 0)}, "
-        f"partial={summary['status_counts'].get('partial', 0)}, "
-        f"missing={summary['status_counts'].get('missing', 0)}, "
-        f"error={summary['status_counts'].get('error', 0)}"
+        f"ok={colors.success(summary['status_counts'].get('ok', 0))}, "
+        f"partial={colors.warning(summary['status_counts'].get('partial', 0))}, "
+        f"missing={colors.error(summary['status_counts'].get('missing', 0))}, "
+        f"error={colors.error(summary['status_counts'].get('error', 0))}"
     )
-    print(f"  invalid:      {summary['invalid_count']}")
+    print(f"  invalid:      {colors.error(summary['invalid_count'])}")
 
-    print("\nPer-sweep:")
+    print("\n" + colors.heading("Per-sweep:"))
     if not rows:
         print("  (none)")
         return
 
     for row in rows:
+        status = _format_status(row.get("sweep_status"), colors=colors)
+        validation = _format_validation(
+            row.get("validation_exit_code"), colors=colors
+        )
         print(
             "  - "
             f"{row.get('run_id') or '(unknown)'} "
             f"[{row.get('beam_model')}/{row.get('sky_model')}] "
-            f"=> {row.get('sweep_status')} "
-            f"(validate={row.get('validation_exit_code')})"
+            f"=> {status} "
+            f"(validate={validation})"
         )
         print(
             "      points: "
             f"total={row.get('points_total')}, "
-            f"ok={row.get('points_ok')}, "
-            f"partial={row.get('points_partial')}, "
-            f"missing={row.get('points_missing')}"
+            f"ok={colors.success(row.get('points_ok'))}, "
+            f"partial={colors.warning(row.get('points_partial'))}, "
+            f"missing={colors.error(row.get('points_missing'))}"
         )
         if row.get("validation_failures"):
             print(
                 "      failures: "
-                + "; ".join(str(x) for x in row["validation_failures"])
+                + colors.error(
+                    "; ".join(str(x) for x in row["validation_failures"])
+                )
             )
         if row.get("error"):
-            print(f"      error: {row['error']}")
-        print(f"      dir: {row.get('sweep_dir')}")
+            print(f"      error: {colors.error(row['error'])}")
+        print(f"      dir: {colors.path(row.get('sweep_dir'))}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -310,7 +340,10 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     else:
-        _print_text(results_root, rows)
+        colors = CliColors(
+            resolve_color_mode(args.color), enabled=not bool(args.json_out)
+        )
+        _print_text(results_root, rows, colors=colors)
 
     if args.fail_on_invalid and int(summary["invalid_count"]) > 0:
         return 1

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_sweep_status.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_sweep_status.py
@@ -8,6 +8,12 @@ import json
 import sys
 from pathlib import Path
 
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    resolve_color_mode,
+)
+
 from .sweep_health import inspect_sweep_health, sweep_health_to_dict
 
 
@@ -41,45 +47,61 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Include per-point note details in text output.",
     )
+    add_color_argument(parser)
     return parser
 
 
-def _print_text(*, health, show_notes: bool) -> None:
-    print("Sweep status summary:")
-    print(f"  sweep_dir:      {health.sweep_dir}")
-    print(f"  sweep_manifest: {health.sweep_manifest_path}")
+def _format_status(status: object, *, colors: CliColors) -> str:
+    text = str(status)
+    if text == "ok":
+        return colors.success(text)
+    if text == "partial":
+        return colors.warning(text)
+    if text in ("missing", "invalid", "error"):
+        return colors.error(text)
+    return text
+
+
+def _print_text(*, health, show_notes: bool, colors: CliColors) -> None:
+    print(colors.heading("Sweep status summary:"))
+    print(f"  sweep_dir:      {colors.path(health.sweep_dir)}")
+    print(f"  sweep_manifest: {colors.path(health.sweep_manifest_path)}")
     if health.run_id is not None:
         print(f"  run_id:         {health.run_id}")
     if health.beam_model is not None:
         print(f"  beam_model:     {health.beam_model}")
     if health.sky_model is not None:
         print(f"  sky_model:      {health.sky_model}")
-    print(f"  sweep_status:   {health.sweep_status}")
+    print(
+        f"  sweep_status:   "
+        f"{_format_status(health.sweep_status, colors=colors)}"
+    )
     print(f"  points_total:   {health.points_total}")
-    print(f"  points_ok:      {health.points_ok}")
-    print(f"  points_partial: {health.points_partial}")
-    print(f"  points_missing: {health.points_missing}")
+    print(f"  points_ok:      {colors.success(health.points_ok)}")
+    print(f"  points_partial: {colors.warning(health.points_partial)}")
+    print(f"  points_missing: {colors.error(health.points_missing)}")
 
     if health.messages:
-        print("  messages:")
+        print(colors.heading("  messages:"))
         for msg in health.messages:
-            print(f"    - {msg}")
+            print(f"    - {colors.warning(msg)}")
 
-    print("\nPer-point:")
+    print("\n" + colors.heading("Per-point:"))
     if not health.point_rows:
         print("  (none)")
         return
 
     for row in health.point_rows:
+        point_status = _format_status(row.point_status, colors=colors)
         print(
             "  - "
             f"{row.run_label} "
             f"({row.perturb_parameter}={row.perturb_frac:+.3f}) "
-            f"=> {row.point_status}"
+            f"=> {point_status}"
         )
         if show_notes and row.notes:
             for note in row.notes:
-                print(f"      note: {note}")
+                print(f"      note: {colors.warning(note)}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -95,7 +117,10 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(sweep_health_to_dict(health), indent=2))
         return 0
 
-    _print_text(health=health, show_notes=bool(args.show_notes))
+    colors = CliColors(
+        resolve_color_mode(args.color), enabled=not bool(args.json_out)
+    )
+    _print_text(health=health, show_notes=bool(args.show_notes), colors=colors)
     return 0
 
 

--- a/src/valska_hera_beam/external_tools/bayeseor/cli_validate_sweep.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/cli_validate_sweep.py
@@ -8,6 +8,12 @@ import json
 import sys
 from pathlib import Path
 
+from valska_hera_beam.cli_format import (
+    CliColors,
+    add_color_argument,
+    resolve_color_mode,
+)
+
 from .sweep_health import (
     inspect_sweep_health,
     sweep_health_to_dict,
@@ -50,29 +56,50 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print machine-readable JSON payload.",
     )
+    add_color_argument(parser)
     return parser
 
 
-def _print_text(*, health, failures: list[str], exit_code: int) -> None:
-    print("Sweep validation:")
-    print(f"  sweep_dir:    {health.sweep_dir}")
-    print(f"  sweep_status: {health.sweep_status}")
+def _format_status(status: object, *, colors: CliColors) -> str:
+    text = str(status)
+    if text == "ok":
+        return colors.success(text)
+    if text == "partial":
+        return colors.warning(text)
+    if text in ("missing", "invalid", "error"):
+        return colors.error(text)
+    return text
+
+
+def _print_text(
+    *, health, failures: list[str], exit_code: int, colors: CliColors
+) -> None:
+    print(colors.heading("Sweep validation:"))
+    print(f"  sweep_dir:    {colors.path(health.sweep_dir)}")
+    print(
+        f"  sweep_status: {_format_status(health.sweep_status, colors=colors)}"
+    )
     print(
         "  points:       "
         f"total={health.points_total}, "
-        f"ok={health.points_ok}, "
-        f"partial={health.points_partial}, "
-        f"missing={health.points_missing}"
+        f"ok={colors.success(health.points_ok)}, "
+        f"partial={colors.warning(health.points_partial)}, "
+        f"missing={colors.error(health.points_missing)}"
     )
 
     if failures:
-        print("  failures:")
+        print(colors.heading("  failures:"))
         for item in failures:
-            print(f"    - {item}")
+            print(f"    - {colors.error(item)}")
     else:
-        print("  failures:     none")
+        print(f"  failures:     {colors.success('none')}")
 
-    print(f"  exit_code:    {exit_code}")
+    exit_code_display = (
+        colors.success(exit_code)
+        if exit_code == 0
+        else colors.error(exit_code)
+    )
+    print(f"  exit_code:    {exit_code_display}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -101,7 +128,15 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2))
         return exit_code
 
-    _print_text(health=health, failures=failures, exit_code=exit_code)
+    colors = CliColors(
+        resolve_color_mode(args.color), enabled=not bool(args.json_out)
+    )
+    _print_text(
+        health=health,
+        failures=failures,
+        exit_code=exit_code,
+        colors=colors,
+    )
     return exit_code
 
 

--- a/src/valska_hera_beam/external_tools/bayeseor/report.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/report.py
@@ -8,6 +8,7 @@ import json
 import math
 import os
 import re
+from collections.abc import Mapping
 from contextlib import redirect_stdout
 from dataclasses import asdict, dataclass
 from os.path import commonpath
@@ -39,6 +40,12 @@ _TICK_LABEL_FONTSIZE = 11
 _TITLE_FONTSIZE = 14
 _LEGEND_FONTSIZE = 10
 _PLOT_DPI = 300
+
+
+_LEGACY_PERTURBATION_FIELDS = {
+    "fwhm_perturb_frac": "fwhm_deg",
+    "antenna_diameter_perturb_frac": "antenna_diameter",
+}
 
 
 @dataclass(frozen=True)
@@ -347,6 +354,28 @@ def _write_summary_json(
     )
 
 
+def _read_point_perturbation(point: Mapping[str, Any]) -> tuple[str, float]:
+    """Read perturbation metadata from current or legacy sweep manifests."""
+    perturb_parameter = point.get("perturb_parameter")
+
+    perturb_frac = point.get("perturb_frac")
+    if perturb_frac is not None:
+        return str(perturb_parameter or "unknown"), float(perturb_frac)
+
+    for field, default_parameter in _LEGACY_PERTURBATION_FIELDS.items():
+        perturb_frac = point.get(field)
+        if perturb_frac is not None:
+            return str(perturb_parameter or default_parameter), float(
+                perturb_frac
+            )
+
+    raise ValueError(
+        "Sweep point is missing perturbation fraction metadata; expected "
+        "'perturb_frac' or one of "
+        f"{sorted(_LEGACY_PERTURBATION_FIELDS)}."
+    )
+
+
 def generate_sweep_report(
     *,
     sweep_dir: Path,
@@ -382,8 +411,7 @@ def generate_sweep_report(
     signal_chain_roots: list[tuple[str, Path]] = []
     chain_pairs: dict[str, ChainPair] = {}
     for point in points:
-        perturb_parameter = str(point.get("perturb_parameter", "unknown"))
-        perturb_frac = float(point.get("perturb_frac"))
+        perturb_parameter, perturb_frac = _read_point_perturbation(point)
         run_label = str(point.get("run_label", ""))
         run_dir = Path(str(point.get("run_dir", ""))).expanduser().resolve()
 

--- a/src/valska_hera_beam/external_tools/bayeseor/report.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/report.py
@@ -92,6 +92,7 @@ class SweepReportResult:
     plot_analysis_results_png: Path | None
     complete_analysis_json: Path | None
     complete_analysis_csv: Path | None
+    complete_analysis_rows: list[dict[str, Any]]
 
 
 def _parse_float_or_none(raw: str) -> float | None:
@@ -498,6 +499,7 @@ def generate_sweep_report(
 
     complete_analysis_json: Path | None = None
     complete_analysis_csv: Path | None = None
+    complete_analysis_rows: list[dict[str, Any]] = []
     if include_complete_analysis_table and chain_pairs:
         buffer = io.StringIO()
         if show_progress:
@@ -539,16 +541,19 @@ def generate_sweep_report(
         )
 
         successful_rows = complete_res.get("successful_results", [])
+        complete_analysis_rows = (
+            list(successful_rows) if isinstance(successful_rows, list) else []
+        )
         complete_analysis_csv = report_dir / "complete_analysis_successful.csv"
-        if successful_rows:
-            headers = list(successful_rows[0].keys())
+        if complete_analysis_rows:
+            headers = list(complete_analysis_rows[0].keys())
             with complete_analysis_csv.open(
                 "w", encoding="utf-8", newline=""
             ) as handle:
                 dict_writer = csv.DictWriter(handle, fieldnames=headers)
                 dict_writer.writeheader()
-                for row in successful_rows:
-                    dict_writer.writerow(row)
+                for complete_row in complete_analysis_rows:
+                    dict_writer.writerow(complete_row)
         else:
             with complete_analysis_csv.open(
                 "w", encoding="utf-8", newline=""
@@ -595,4 +600,5 @@ def generate_sweep_report(
             if complete_analysis_csv and complete_analysis_csv.exists()
             else None
         ),
+        complete_analysis_rows=complete_analysis_rows,
     )

--- a/src/valska_hera_beam/external_tools/bayeseor/report.py
+++ b/src/valska_hera_beam/external_tools/bayeseor/report.py
@@ -6,6 +6,7 @@ import csv
 import io
 import json
 import math
+import os
 import re
 from contextlib import redirect_stdout
 from dataclasses import asdict, dataclass
@@ -14,6 +15,13 @@ from pathlib import Path
 from typing import Any, Literal
 
 import matplotlib.pyplot as plt
+from rich.console import Console
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
 
 from valska_hera_beam.evidence import ChainPair, run_complete_bayeseor_analysis
 from valska_hera_beam.plotting import BeamAnalysisPlotter
@@ -346,6 +354,7 @@ def generate_sweep_report(
     make_plots: bool = True,
     include_plot_analysis_results: bool = False,
     include_complete_analysis_table: bool = False,
+    show_progress: bool = False,
 ) -> SweepReportResult:
     """Generate summary table(s) and plots for an existing sweep directory."""
     sweep_dir = Path(sweep_dir).expanduser().resolve()
@@ -491,13 +500,37 @@ def generate_sweep_report(
     complete_analysis_csv: Path | None = None
     if include_complete_analysis_table and chain_pairs:
         buffer = io.StringIO()
-        with redirect_stdout(buffer):
-            complete_res = run_complete_bayeseor_analysis(
-                chain_pairs=chain_pairs,
-                create_plots=False,
-                verbose=False,
-                show_progress=False,
+        if show_progress:
+            progress_console = Console(
+                stderr=True,
+                force_terminal=True,
+                no_color=os.environ.get("NO_COLOR") is not None,
             )
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                TimeElapsedColumn(),
+                console=progress_console,
+                transient=True,
+            ) as progress:
+                progress.add_task(
+                    "Running complete BayesEoR analysis", total=None
+                )
+                with redirect_stdout(buffer):
+                    complete_res = run_complete_bayeseor_analysis(
+                        chain_pairs=chain_pairs,
+                        create_plots=False,
+                        verbose=False,
+                        show_progress=False,
+                    )
+        else:
+            with redirect_stdout(buffer):
+                complete_res = run_complete_bayeseor_analysis(
+                    chain_pairs=chain_pairs,
+                    create_plots=False,
+                    verbose=False,
+                    show_progress=False,
+                )
 
         complete_analysis_json = report_dir / "complete_analysis_results.json"
         complete_analysis_json.write_text(

--- a/tests/test_bayeseor_cleanup.py
+++ b/tests/test_bayeseor_cleanup.py
@@ -113,6 +113,28 @@ def test_cleanup_dry_run_plans_actions(tmp_path: Path, capsys) -> None:
     assert point_missing.exists()
 
 
+def test_cleanup_color_always(tmp_path: Path, capsys, monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    results_root = tmp_path / "results"
+    _mk_sweep(results_root, "sweep_cleanup")
+
+    code = cli_cleanup.main(
+        [
+            "--results-root",
+            str(results_root),
+            "--prune-logs",
+            "--color",
+            "always",
+        ]
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "Sweep cleanup summary:" in out
+    assert "Actions:" in out
+
+
 def test_cleanup_execute_prune_runs_requires_confirm(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_bayeseor_cli.py
+++ b/tests/test_bayeseor_cli.py
@@ -130,6 +130,93 @@ def test_cli_sweep_antenna_mode_dry_run_returns_0():
     assert code == 0
 
 
+def test_cli_sweep_dry_run_color_always(capsys, monkeypatch):
+    """Dry-run output can be colorized explicitly for demos."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    code = cli_sweep.main(
+        [
+            "--beam",
+            "airy",
+            "--sky",
+            "GLEAM_plus_GSM",
+            "--data",
+            "input.uvh5",
+            "--run-id",
+            "r001",
+            "--perturb-parameter",
+            "antenna_diameter",
+            "--antenna-diameter-fracs",
+            "0.0",
+            "--dry-run",
+            "--color",
+            "always",
+        ]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "[DRY RUN] Sweep would be executed with:" in out
+
+
+def test_cli_sweep_dry_run_color_never(capsys):
+    """Dry-run output remains plain when color is disabled."""
+    code = cli_sweep.main(
+        [
+            "--beam",
+            "airy",
+            "--sky",
+            "GLEAM_plus_GSM",
+            "--data",
+            "input.uvh5",
+            "--run-id",
+            "r001",
+            "--perturb-parameter",
+            "antenna_diameter",
+            "--antenna-diameter-fracs",
+            "0.0",
+            "--dry-run",
+            "--color",
+            "never",
+        ]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "\x1b[" not in out
+    assert "[runtime_paths.yaml:data.root]" in out
+
+
+def test_cli_sweep_dry_run_no_color_env_suppresses_color(capsys, monkeypatch):
+    """NO_COLOR suppresses ANSI output even when color is requested."""
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    code = cli_sweep.main(
+        [
+            "--beam",
+            "airy",
+            "--sky",
+            "GLEAM_plus_GSM",
+            "--data",
+            "input.uvh5",
+            "--run-id",
+            "r001",
+            "--perturb-parameter",
+            "antenna_diameter",
+            "--antenna-diameter-fracs",
+            "0.0",
+            "--dry-run",
+            "--color",
+            "always",
+        ]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "\x1b[" not in out
+
+
 def test_cli_sweep_rejects_mismatched_perturbation_flags():
     """
     sweep should reject fwhm-only flags when perturb_parameter is antenna_diameter.

--- a/tests/test_bayeseor_compare_sweeps.py
+++ b/tests/test_bayeseor_compare_sweeps.py
@@ -179,6 +179,48 @@ def test_cli_compare_sweeps_metric_and_missing_metric_skip(
     assert abs(payload["top_differences"][0]["delta"] - 0.1) < 1e-12
 
 
+def test_cli_compare_sweeps_color_always(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    left = tmp_path / "left.json"
+    right = tmp_path / "right.json"
+    _write_summary(
+        left,
+        [
+            _point(
+                "antdiam_0.0e+00",
+                perturb_frac=0.0,
+                status="ok",
+                delta=1.0,
+                log10_bf=0.2,
+            )
+        ],
+    )
+    _write_summary(
+        right,
+        [
+            _point(
+                "antdiam_0.0e+00",
+                perturb_frac=0.0,
+                status="ok",
+                delta=1.2,
+                log10_bf=0.3,
+            )
+        ],
+    )
+
+    code = cli_compare_sweeps.main(
+        [str(left), str(right), "--color", "always"]
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "Sweep comparison summary:" in out
+    assert "antdiam_0.0e+00" in out
+
+
 def test_cli_compare_sweeps_missing_input_returns_2(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_bayeseor_list_sweeps.py
+++ b/tests/test_bayeseor_list_sweeps.py
@@ -102,6 +102,27 @@ def test_list_sweeps_latest(tmp_path: Path, capsys) -> None:
     assert payload["sweeps"][0]["run_id"] == "sweep_new"
 
 
+def test_list_sweeps_color_always(tmp_path: Path, capsys, monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    results_root = tmp_path / "results"
+    _mk_sweep(
+        results_root,
+        beam="airy_diam14m",
+        sky="GSM_plus_GLEAM",
+        run_id="sweep_color",
+        created_utc="2026-02-20T20:00:00Z",
+    )
+
+    code = cli_list_sweeps.main(
+        ["--results-root", str(results_root), "--color", "always"]
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "sweep_color" in out
+
+
 def test_list_sweeps_missing_search_root_returns_2(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_bayeseor_report.py
+++ b/tests/test_bayeseor_report.py
@@ -171,6 +171,7 @@ def test_cli_report_progress_always_is_passed_to_report(
             plot_analysis_results_png=None,
             complete_analysis_json=None,
             complete_analysis_csv=None,
+            complete_analysis_rows=[],
         )
 
     monkeypatch.setattr(
@@ -210,6 +211,7 @@ def test_cli_report_json_disables_progress(
             plot_analysis_results_png=None,
             complete_analysis_json=None,
             complete_analysis_csv=None,
+            complete_analysis_rows=[],
         )
 
     monkeypatch.setattr(
@@ -229,6 +231,129 @@ def test_cli_report_json_disables_progress(
     assert code == 0
     assert calls["show_progress"] is False
     json.loads(capsys.readouterr().out)
+
+
+def test_cli_report_prints_color_complete_analysis_table(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    def fake_generate_sweep_report(**kwargs):
+        assert kwargs["include_complete_analysis_table"] is True
+        return cli_report.SweepReportResult(
+            sweep_dir=tmp_path,
+            out_dir=tmp_path / "report",
+            evidence_source="ins",
+            rows_total=2,
+            rows_complete=2,
+            summary_csv=tmp_path / "report" / "summary.csv",
+            summary_json=tmp_path / "report" / "summary.json",
+            delta_plot_png=None,
+            evidence_plot_png=None,
+            plot_analysis_results_png=None,
+            complete_analysis_json=tmp_path
+            / "report"
+            / "complete_analysis_results.json",
+            complete_analysis_csv=tmp_path
+            / "report"
+            / "complete_analysis_successful.csv",
+            complete_analysis_rows=[
+                {
+                    "perturbation": "antdiam_1.0e-01",
+                    "log_bayes_factor": 3.0,
+                    "validation": "FAIL",
+                    "interpretation": "Strong evidence for model 1",
+                },
+                {
+                    "perturbation": "antdiam_1.0e-02",
+                    "log_bayes_factor": -2.5,
+                    "validation": "PASS",
+                    "interpretation": "Strong evidence for model 2",
+                },
+            ],
+        )
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(
+        cli_report, "generate_sweep_report", fake_generate_sweep_report
+    )
+
+    code = cli_report.main(
+        [
+            str(tmp_path),
+            "--print-complete-analysis-table",
+            "--color",
+            "always",
+        ]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "Complete BayesEoR Perturbation Analysis Summary" in out
+    assert "ΔD/D = +1.00%" in out
+    assert out.index("ΔD/D = +1.00%") < out.index("ΔD/D = +10.00%")
+    assert "✅ PASS" in out
+    assert "❌ FAIL" in out
+
+
+def test_cli_report_prints_plain_complete_analysis_table(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    def fake_generate_sweep_report(**kwargs):
+        assert kwargs["include_complete_analysis_table"] is True
+        return cli_report.SweepReportResult(
+            sweep_dir=tmp_path,
+            out_dir=tmp_path / "report",
+            evidence_source="ins",
+            rows_total=1,
+            rows_complete=1,
+            summary_csv=tmp_path / "report" / "summary.csv",
+            summary_json=tmp_path / "report" / "summary.json",
+            delta_plot_png=None,
+            evidence_plot_png=None,
+            plot_analysis_results_png=None,
+            complete_analysis_json=None,
+            complete_analysis_csv=None,
+            complete_analysis_rows=[
+                {
+                    "perturbation": "antdiam_1.0e-02",
+                    "log_bayes_factor": -2.5,
+                    "validation": "PASS",
+                    "interpretation": "Strong evidence for model 2",
+                }
+            ],
+        )
+
+    monkeypatch.setattr(
+        cli_report, "generate_sweep_report", fake_generate_sweep_report
+    )
+
+    code = cli_report.main(
+        [
+            str(tmp_path),
+            "--print-complete-analysis-table",
+            "--complete-analysis-table-style",
+            "plain",
+            "--color",
+            "never",
+        ]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "\x1b[" not in out
+    assert "PASS" in out
+    assert "✅ PASS" not in out
+
+
+def test_cli_report_rejects_print_table_with_json(
+    tmp_path: Path, capsys
+) -> None:
+    code = cli_report.main(
+        [str(tmp_path), "--json", "--print-complete-analysis-table"]
+    )
+
+    assert code == 2
+    assert "cannot be combined with --json" in capsys.readouterr().err
 
 
 def test_generate_sweep_report_marks_incomplete_when_chain_file_missing(

--- a/tests/test_bayeseor_report.py
+++ b/tests/test_bayeseor_report.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from valska_hera_beam.external_tools.bayeseor import cli_report
 from valska_hera_beam.external_tools.bayeseor.report import (
     generate_sweep_report,
@@ -120,6 +122,53 @@ def test_generate_sweep_report_writes_outputs(tmp_path: Path) -> None:
     first = payload["points"][0]
     assert first["status"] == "ok"
     assert first["delta_log_evidence"] is not None
+
+
+@pytest.mark.parametrize(
+    ("legacy_key", "expected_parameter"),
+    [
+        ("fwhm_perturb_frac", "fwhm_deg"),
+        ("antenna_diameter_perturb_frac", "antenna_diameter"),
+    ],
+)
+def test_generate_sweep_report_supports_legacy_perturbation_fields(
+    tmp_path: Path,
+    legacy_key: str,
+    expected_parameter: str,
+) -> None:
+    sweep_dir = tmp_path / "_sweeps" / "legacy_sweep"
+    point = sweep_dir / "validation" / "legacy_1.0e-02"
+    _mk_point(point, signal_ns=12.0, no_signal_ns=10.0)
+
+    manifest = {
+        "points": [
+            {
+                legacy_key: 0.01,
+                "run_label": "legacy_1.0e-02",
+                "run_dir": str(point),
+            }
+        ]
+    }
+    sweep_dir.mkdir(parents=True, exist_ok=True)
+    (sweep_dir / "sweep_manifest.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
+    result = generate_sweep_report(
+        sweep_dir=sweep_dir,
+        out_dir=None,
+        evidence_source="ins",
+        make_plots=False,
+    )
+
+    assert result.rows_total == 1
+    assert result.rows_complete == 1
+
+    payload = json.loads(result.summary_json.read_text(encoding="utf-8"))
+    row = payload["points"][0]
+    assert row["status"] == "ok"
+    assert row["perturb_parameter"] == expected_parameter
+    assert row["perturb_frac"] == 0.01
 
 
 def test_cli_report_json_output(tmp_path: Path, capsys) -> None:

--- a/tests/test_bayeseor_report.py
+++ b/tests/test_bayeseor_report.py
@@ -151,6 +151,86 @@ def test_cli_report_json_output(tmp_path: Path, capsys) -> None:
     assert payload["rows_complete"] == 1
 
 
+def test_cli_report_progress_always_is_passed_to_report(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls = {}
+
+    def fake_generate_sweep_report(**kwargs):
+        calls.update(kwargs)
+        return cli_report.SweepReportResult(
+            sweep_dir=tmp_path,
+            out_dir=tmp_path / "report",
+            evidence_source="ins",
+            rows_total=1,
+            rows_complete=1,
+            summary_csv=tmp_path / "report" / "summary.csv",
+            summary_json=tmp_path / "report" / "summary.json",
+            delta_plot_png=None,
+            evidence_plot_png=None,
+            plot_analysis_results_png=None,
+            complete_analysis_json=None,
+            complete_analysis_csv=None,
+        )
+
+    monkeypatch.setattr(
+        cli_report, "generate_sweep_report", fake_generate_sweep_report
+    )
+
+    code = cli_report.main(
+        [
+            str(tmp_path),
+            "--include-complete-analysis-table",
+            "--progress",
+            "always",
+        ]
+    )
+
+    assert code == 0
+    assert calls["show_progress"] is True
+
+
+def test_cli_report_json_disables_progress(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    calls = {}
+
+    def fake_generate_sweep_report(**kwargs):
+        calls.update(kwargs)
+        return cli_report.SweepReportResult(
+            sweep_dir=tmp_path,
+            out_dir=tmp_path / "report",
+            evidence_source="ins",
+            rows_total=1,
+            rows_complete=1,
+            summary_csv=tmp_path / "report" / "summary.csv",
+            summary_json=tmp_path / "report" / "summary.json",
+            delta_plot_png=None,
+            evidence_plot_png=None,
+            plot_analysis_results_png=None,
+            complete_analysis_json=None,
+            complete_analysis_csv=None,
+        )
+
+    monkeypatch.setattr(
+        cli_report, "generate_sweep_report", fake_generate_sweep_report
+    )
+
+    code = cli_report.main(
+        [
+            str(tmp_path),
+            "--include-complete-analysis-table",
+            "--progress",
+            "always",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    assert calls["show_progress"] is False
+    json.loads(capsys.readouterr().out)
+
+
 def test_generate_sweep_report_marks_incomplete_when_chain_file_missing(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_bayeseor_report_all.py
+++ b/tests/test_bayeseor_report_all.py
@@ -129,6 +129,36 @@ def test_cli_report_all_json_and_only_new(tmp_path: Path, capsys) -> None:
     assert payload["summary"]["count_errors"] == 0
 
 
+def test_cli_report_all_color_always(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    results_root = tmp_path / "results"
+    _mk_sweep(
+        results_root,
+        beam="airy_diam14m",
+        sky="GSM_plus_GLEAM",
+        run_id="sweep_color",
+        with_points=True,
+    )
+
+    code = cli_report_all.main(
+        [
+            "--results-root",
+            str(results_root),
+            "--no-plots",
+            "--color",
+            "always",
+        ]
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "Sweep batch report summary:" in out
+    assert "sweep_color" in out
+
+
 def test_cli_report_all_fail_on_error_returns_1(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_bayeseor_resume.py
+++ b/tests/test_bayeseor_resume.py
@@ -129,6 +129,19 @@ def test_cli_resume_stage_cpu_only(tmp_path: Path, capsys) -> None:
     ]
 
 
+def test_cli_resume_color_always(tmp_path: Path, capsys, monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    sweep_dir = _mk_sweep(tmp_path)
+
+    code = cli_resume.main([str(sweep_dir), "--color", "always"])
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "Sweep resume suggestions:" in out
+    assert "valska-bayeseor-submit" in out
+
+
 def test_cli_resume_missing_manifest_returns_2(tmp_path: Path, capsys) -> None:
     code = cli_resume.main([str(tmp_path / "missing")])
     assert code == 2

--- a/tests/test_bayeseor_sweep_audit.py
+++ b/tests/test_bayeseor_sweep_audit.py
@@ -135,6 +135,28 @@ def test_sweep_audit_fail_on_invalid(tmp_path: Path) -> None:
     assert code == 1
 
 
+def test_sweep_audit_color_always(tmp_path: Path, capsys, monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    results_root = tmp_path / "results"
+    _mk_sweep(
+        results_root,
+        beam="airy_diam14m",
+        sky="GSM_plus_GLEAM",
+        run_id="sweep_partial",
+        point_kind="partial",
+    )
+
+    code = cli_sweep_audit.main(
+        ["--results-root", str(results_root), "--color", "always"]
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "Sweep audit summary:" in out
+    assert "sweep_partial" in out
+
+
 def test_sweep_audit_missing_search_root_returns_2(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_bayeseor_sweep_health.py
+++ b/tests/test_bayeseor_sweep_health.py
@@ -97,6 +97,21 @@ def test_cli_sweep_status_json(tmp_path: Path, capsys) -> None:
     assert payload["points_partial"] == 1
 
 
+def test_cli_sweep_status_color_always(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    sweep_dir = _mk_sweep(tmp_path)
+
+    code = cli_sweep_status.main([str(sweep_dir), "--color", "always"])
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "Sweep status summary:" in out
+    assert "partial" in out
+
+
 def test_cli_validate_sweep_fails_without_allow_partial(
     tmp_path: Path, capsys
 ) -> None:
@@ -105,6 +120,21 @@ def test_cli_validate_sweep_fails_without_allow_partial(
     code = cli_validate_sweep.main([str(sweep_dir)])
     assert code == 1
     assert "Sweep status is 'partial'" in capsys.readouterr().out
+
+
+def test_cli_validate_sweep_color_always(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    sweep_dir = _mk_sweep(tmp_path)
+
+    code = cli_validate_sweep.main([str(sweep_dir), "--color", "always"])
+    assert code == 1
+
+    out = capsys.readouterr().out
+    assert "\x1b[" in out
+    assert "Sweep validation:" in out
+    assert "exit_code:" in out
 
 
 def test_cli_validate_sweep_allow_partial_but_require_jobs_json(


### PR DESCRIPTION
# Description
This PR improves the terminal UX for the BayesEoR CLI tools by adding consistent Rich-based color formatting and shared CLI formatting helpers.

The first colour/progress work added support to selected commands (`valska-bayeseor-sweep --dry-run` and `valska-bayeseor-report`). This follow-up makes the behaviour more consistent across the BayesEoR inspection/reporting utilities while preserving plain JSON output for machine-readable workflows.

Main changes:
- Adds shared helpers in `src/valska_hera_beam/cli_format.py` for standard `--color` and `--progress` options.
- Applies `--color auto|always|never` consistently to human-readable output for:
  - `valska-bayeseor-sweep --dry-run`
  - `valska-bayeseor-report`
  - `valska-bayeseor-report-all`
  - `valska-bayeseor-list-sweeps`
  - `valska-bayeseor-sweep-status`
  - `valska-bayeseor-validate-sweep`
  - `valska-bayeseor-sweep-audit`
  - `valska-bayeseor-resume`
  - `valska-bayeseor-compare-sweeps`
  - `valska-bayeseor-cleanup`
- Applies shared `--progress auto|always|never` handling to report/report-all complete-analysis paths.
- Keeps `--json` output uncoloured and machine-readable.
- Adds regression tests for explicit `--colour always` behaviour, including handling environments where `NO_COLOR` is set.

Related context:
- This supports the recent work to make report table output and longer-running report commands more useful for demos and interactive terminal use.

## Type of change
- New feature
- Other: CLI usability and consistency improvement


## Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (`make python-test`)
- [x] Linting/formatting checks pass locally (`make python-format`, `make python-lint`)
- [x] I have added or updated unit tests for my changes, where applicable
- [ ] I have updated relevant documentation (README, docs, docstrings, examples), where applicable and checked that the new documentation has rendered correctly in ReadTheDocs
- [ ] I have linked any related issues and requested appropriate reviewers

Local validation run:
```bash
python -m pytest \
  tests/test_bayeseor_report.py \
  tests/test_bayeseor_report_all.py \
  tests/test_bayeseor_cli.py \
  tests/test_bayeseor_sweep_health.py \
  tests/test_bayeseor_list_sweeps.py \
  tests/test_bayeseor_sweep_audit.py \
  tests/test_bayeseor_compare_sweeps.py \
  tests/test_bayeseor_resume.py \
  tests/test_bayeseor_cleanup.py \
  -q
```

Result:
```text
51 passed
```

Pre-commit was also run on the touched files and passed.