### PR TITLE
Fix create path manager test failing on macOS

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -292,13 +292,17 @@ def test_create_path_manager_default(pm, chains):
 
             assert path_manager.utils_dir == test_dir.parent.resolve()
             assert path_manager.package_dir == test_dir.parent.resolve()
-            assert path_manager.base_dir == Path(base_dir).resolve()
+            assert path_manager.base_dir.resolve() == Path(base_dir).resolve()
             assert (
-                path_manager.chains_dir == Path(base_dir + "/chains").resolve()
+                path_manager.chains_dir.resolve()
+                == Path(base_dir + "/chains").resolve()
             )
-            assert path_manager.data_dir == Path(base_dir + "/data").resolve()
             assert (
-                path_manager.results_dir
+                path_manager.data_dir.resolve()
+                == Path(base_dir + "/data").resolve()
+            )
+            assert (
+                path_manager.results_dir.resolve()
                 == Path(base_dir + "/results").resolve()
             )
 


### PR DESCRIPTION
# Description
I was getting the following failed test error when I ran `make python-test` locally. The test [`test_create_path_manager_default` in `test_utils.py`](https://github.com/uksrc/ValSKA-HERA-beam-FWHM/blob/9f73f14881c4dfad2dc1bc8f1a336e2a0f2b7381/tests/test_utils.py#L242) was failing when run with the last two parameters `("method", True),("method", False)`:

```
E               AssertionError: assert PosixPath('/var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym') == PosixPath('/private/var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym')
E                +  where PosixPath('/var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym') = PathManager:\n  utils_dir: /private/var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym/one/two\n  package_dir: ...07858vlq5c0000gp/T/tmpl8a4anym/data\n  results_dir: /var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym/results.base_dir
E                +  and   PosixPath('/private/var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym') = resolve()
E                +    where resolve = PosixPath('/var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym').resolve
E                +      where PosixPath('/var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym') = Path('/var/folders/nk/ydscdj7s607gz707858vlq5c0000gp/T/tmpl8a4anym')

tests/test_utils.py:297: AssertionError
```

The test was failing because the `TemporaryDirectory` passed to the `base_dir` variable is at `/var/...` but the test compares the resolved symlink to `/private/var/..` on macOS. See https://apple.stackexchange.com/questions/1043/why-is-tmp-a-symlink-to-private-tmp for more info.

As discussed with @epolehampton, it seems it is better to fix the test by comparing two resolved paths rather than fixing `PathManager` as ultimately it is dealing with the same folder.

## Type of change
- Bugfix

## Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (`make python-test`)
- [x] Linting/formatting checks pass locally (`make python-format`, `make python-lint`)
- [x] I have added or updated unit tests for my changes, where applicable
- [x] I have updated relevant documentation (README, docs, docstrings, examples), where applicable and checked that the new documentation has rendered correctly in ReadTheDocs
- [x] I have linked any related issues and requested appropriate reviewers
