### PR TITLE
Add valska-data-preflight checks for incoming data

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,6 +10,7 @@ deprecated compatibility shim for downstream users migrating existing code.
    :recursive:
 
    valska.beam_metrics
+   valska.data_preflight
    valska.evidence
    valska.notebook_helpers
    valska.plotting

--- a/docs/source/workflows.rst
+++ b/docs/source/workflows.rst
@@ -10,3 +10,4 @@ Workflows
    workflows/bayeseor_validation
    workflows/verifying_prepared_outputs
    workflows/pyuvsim_cli_examples
+   workflows/data_preflight

--- a/docs/source/workflows/data_preflight.md
+++ b/docs/source/workflows/data_preflight.md
@@ -1,0 +1,162 @@
+# Pre-flight data checks (`valska-data-preflight`)
+
+## Purpose and limitations
+
+`valska-data-preflight` runs cheap, self-contained checks against UVH5 visibility
+files before they are used in an expensive analysis (e.g. a BayesEoR sweep), so that
+inconsistencies in a file's recorded metadata can be caught early rather than
+discovered after the analysis has already run.
+
+The checks compare pieces of **recorded metadata against each other** — for
+example, whether a file's own name agrees with the beam type declared by the
+telescope config its `pyuvsim` history cites. This is **provenance-consistency
+checking, not proof of what a file's data actually contain**:
+
+- the recorded `history` string may itself be inaccurate or stale;
+- a config file located by name in the search directories may not be
+  byte-identical to whatever configuration was actually in effect at
+  simulation time;
+- agreement between a file's name and its cited config is useful supporting
+  evidence, not a guarantee; disagreement is a strong, actionable signal to
+  investigate before using the file, not proof that nothing else is wrong.
+
+Only fast, header-only checks are implemented currently (the `fast` tier: see
+`valska.data_preflight.registry.CheckTier`). A reference-file comparison tier and
+a `hera_pspec`-based delay-domain diagnostic tier are anticipated but not yet
+built.
+
+## Advisory versus strict behaviour, and exit codes
+
+The **scientific checks** (e.g. `beam_type_consistency`, `metadata_summary`) are
+advisory only by default: a run always exits `0` regardless of PASS/WARN/FAIL/SKIP
+results. Pass `--strict` to exit non-zero if any scientific check result is FAIL,
+for use as a script-level gate.
+
+**Input-discovery and file-read problems are a separate matter** and always
+produce a non-zero exit, independent of `--strict`, so they cannot be silently
+missed:
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Clean run: every requested path existed, every discovered file was read successfully, and (if `--strict`) no scientific check FAILed. |
+| `1` | `--strict` was passed and at least one scientific check FAILed. Only reached when there were no missing paths or read errors (those take precedence). |
+| `2` | Every requested path existed, but none contained (or was) a `.uvh5` file, so there was nothing to check. |
+| `3` | One or more requested paths did not exist, and/or one or more discovered files failed to read (e.g. corrupt file, missing `Header` group, unreadable scalar field). Independent of `--strict`. Other requested paths that did exist, and other files that did read successfully, are still processed and reported. |
+
+A requested path that exists but is an empty directory (or one with no `.uvh5`
+files) is not treated as "missing" — it was found, it simply contributed no
+files.
+
+A file reachable via more than one requested path (passed directly and also
+matched by scanning a parent directory, or passed twice) is only inspected and
+reported once.
+
+## Configuration-search precedence
+
+`beam_type_consistency` needs to locate the telescope config file(s) a UVH5
+file's history cites, by filename, in an ordered list of search directories:
+
+1. Any directories passed via `--config-search-dir` (may be repeated), in the
+   order given.
+2. This repository's own shipped `pyuvsim` telescope configs
+   (`valska.external_tools.pyuvsim`'s packaged `templates/telescope_config`
+   directory and its parent `templates` directory), appended after any
+   `--config-search-dir` directories.
+
+The first directory in this combined, ordered list containing a file with the
+cited name is used. If a cited config file cannot be located in any search
+directory, the check reports `WARN` (not `FAIL`) for that citation, since the
+beam type genuinely cannot be confirmed from the information available.
+
+## Usage
+
+### Single file
+
+```bash
+valska-data-preflight path/to/file.uvh5
+```
+
+### Single file, with an expected beam type
+
+```bash
+valska-data-preflight path/to/file.uvh5 --expected-beam-type airy
+```
+
+Flags the file if its cited config declares a beam type other than the one
+given, in addition to the filename-versus-config check. Most useful when you
+already know what beam type a file is supposed to have.
+
+### Recursive directory scan
+
+```bash
+valska-data-preflight path/to/directory
+```
+
+Recurses into the directory and checks every `*.uvh5` file found.
+
+### Multiple paths, mixing files and directories
+
+```bash
+valska-data-preflight path/to/file.uvh5 path/to/directory --config-search-dir extra/configs
+```
+
+### JSON output
+
+```bash
+valska-data-preflight path/to/directory --json
+```
+
+Prints a single JSON object instead of text:
+
+```json
+{
+  "missing_paths": ["path/to/nonexistent.uvh5"],
+  "reports": [
+    {
+      "path": "path/to/file.uvh5",
+      "error": null,
+      "checks": [
+        {
+          "check_id": "beam_type_consistency",
+          "status": "fail",
+          "message": "file name claims beam type(s) ['airy'], but its cited telescope config declares 'gaussian'",
+          "details": {"...": "..."}
+        }
+      ]
+    }
+  ]
+}
+```
+
+`missing_paths` lists any requested path that did not exist. Each entry in
+`reports` corresponds to one discovered file; `error` is non-null (and
+`checks` empty) if the file could not be read at all.
+
+### Strict mode (script-level gate)
+
+```bash
+valska-data-preflight path/to/directory --strict
+```
+
+Exits `1` if any scientific check FAILed (see the exit-code table above for how
+this interacts with missing paths and read errors).
+
+## Example scan and its limits
+
+A scan of the full `UKSRC_val_mock_vis` tree run on 2026-07-23 (152 `.uvh5`
+files) reported, for `beam_type_consistency`: 31 files whose name and
+history-cited config disagreed on beam type (FAIL), 93 files where the cited
+config could not be located so the beam type could not be confirmed either way
+(WARN), 25 files where name and cited config agreed (PASS), and 3 files with
+no config citation in history (SKIP). These are the counts from one specific
+scan on one specific date, over one specific directory tree — **not** a claim
+that no other beam-type mismatches exist anywhere, including within the 93
+WARN cases that could not be checked, or in files/directories not included in
+that scan.
+
+## See also
+
+- [`valska.data_preflight`](../generated/valska.data_preflight.rst) — API
+  reference (check registry, individual checks, header inspection).
+- [Verifying prepared outputs](verifying_prepared_outputs.md) — a related,
+  narrower checker for `valska-bayeseor-prepare` outputs specifically.

--- a/docs/source/workflows/data_preflight.md
+++ b/docs/source/workflows/data_preflight.md
@@ -32,6 +32,10 @@ advisory only by default: a run always exits `0` regardless of PASS/WARN/FAIL/SK
 results. Pass `--strict` to exit non-zero if any scientific check result is FAIL,
 for use as a script-level gate.
 
+`metadata_summary` reports `FAIL` when any required UVH5 header field is absent.
+This remains advisory without `--strict`, while strict mode can therefore reject
+structurally incomplete files.
+
 **Input-discovery and file-read problems are a separate matter** and always
 produce a non-zero exit, independent of `--strict`, so they cannot be silently
 missed:
@@ -110,6 +114,7 @@ Prints a single JSON object instead of text:
 
 ```json
 {
+  "schema_version": 1,
   "missing_paths": ["path/to/nonexistent.uvh5"],
   "reports": [
     {
@@ -128,9 +133,15 @@ Prints a single JSON object instead of text:
 }
 ```
 
+`schema_version` identifies the machine-readable output contract. Consumers
+should reject unsupported versions rather than assuming a compatible shape.
 `missing_paths` lists any requested path that did not exist. Each entry in
 `reports` corresponds to one discovered file; `error` is non-null (and
 `checks` empty) if the file could not be read at all.
+
+The JSON object is still emitted when no files can be inspected, including
+missing-only inputs (exit `3`) and existing paths containing no `.uvh5` files
+(exit `2`). In those cases, `reports` is empty.
 
 ### Strict mode (script-level gate)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ valska-bayeseor-cleanup = "valska.external_tools.bayeseor.cli_cleanup:main"
 valska-bayeseor-help = "valska.external_tools.bayeseor.cli_help:main"
 valska-pyuvsim-prepare = "valska.external_tools.pyuvsim.cli_prepare:main"
 valska-pyuvsim-submit  = "valska.external_tools.pyuvsim.cli_submit:main"
+valska-data-preflight = "valska.data_preflight.cli:main"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/valska/data_preflight/__init__.py
+++ b/src/valska/data_preflight/__init__.py
@@ -1,0 +1,27 @@
+"""Pre-flight inspection checks for incoming data files.
+
+Runs cheap, self-contained checks against a data file (e.g. a UVH5
+visibility file) before it is used in an expensive analysis such as a
+BayesEoR sweep, so mismatches between what a file claims to be and
+what it actually contains can be caught early.
+"""
+
+from __future__ import annotations
+
+from valska.data_preflight.registry import (
+    CheckContext,
+    CheckResult,
+    CheckStatus,
+    CheckTier,
+    list_checks,
+    run_checks,
+)
+
+__all__ = [
+    "CheckContext",
+    "CheckResult",
+    "CheckStatus",
+    "CheckTier",
+    "list_checks",
+    "run_checks",
+]

--- a/src/valska/data_preflight/__init__.py
+++ b/src/valska/data_preflight/__init__.py
@@ -2,8 +2,10 @@
 
 Runs cheap, self-contained checks against a data file (e.g. a UVH5
 visibility file) before it is used in an expensive analysis such as a
-BayesEoR sweep, so mismatches between what a file claims to be and
-what it actually contains can be caught early.
+BayesEoR sweep, so that mismatches between a file's recorded claims
+about itself (filename, cited config) can be caught early. These
+checks compare recorded metadata for internal consistency; they are
+not a guarantee of what the file's data actually contain.
 """
 
 from __future__ import annotations

--- a/src/valska/data_preflight/checks.py
+++ b/src/valska/data_preflight/checks.py
@@ -1,0 +1,265 @@
+"""Built-in pre-flight checks.
+
+Importing this module registers its checks with the registry in
+registry.py (see ``@register_check`` below). Keep individual checks
+small, dependency-light, and focused on one question each.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from valska.data_preflight.registry import (
+    CheckContext,
+    CheckResult,
+    CheckStatus,
+    CheckTier,
+    register_check,
+)
+
+# Keyword -> canonical beam-type label. Mirrors the mapping
+# valska.beam_metrics.TYPE_TO_CLASS uses for pyuvsim config "type"/"class"
+# values, but this module intentionally does not import beam_metrics (it
+# pulls in matplotlib/lmfit, which would make even the free/fast checks
+# here dependency-heavy for no benefit).
+_CONFIG_TYPE_LABELS: dict[str, str] = {
+    "gaussian": "gaussian",
+    "gaussianbeam": "gaussian",
+    "airy": "airy",
+    "airybeam": "airy",
+    "uniform": "uniform",
+    "uniformbeam": "uniform",
+    "short_dipole": "short_dipole",
+    "shortdipolebeam": "short_dipole",
+}
+
+# Keywords looked for directly in a file's own name/path, i.e. what the
+# file's naming *claims* about its beam, independent of any config file.
+# Matched against tokens split on non-alphanumeric characters (not a
+# \b-boundary regex): file names delimit words with "_"/"-"/".", and \b
+# does not treat "_" as a boundary, so "airy_quentin" would otherwise
+# fail to match "airy".
+_PATH_LABEL_KEYWORDS: dict[str, str] = {
+    "gauss": "gaussian",
+    "gaussian": "gaussian",
+    "airy": "airy",
+    "uniform": "uniform",
+}
+_TOKEN_SPLIT_RE = re.compile(r"[^a-zA-Z0-9]+")
+
+_TELESCOPE_CONFIG_RE = re.compile(
+    r"telescope_config/([\w.\-]+\.ya?ml)", re.IGNORECASE
+)
+
+
+class _SafeLoaderWithAnalyticBeamTag(yaml.SafeLoader):
+    pass
+
+
+def _analytic_beam_constructor(
+    loader: yaml.SafeLoader, node: yaml.MappingNode
+) -> dict[Any, Any]:
+    return loader.construct_mapping(node)
+
+
+_SafeLoaderWithAnalyticBeamTag.add_constructor(
+    "!AnalyticBeam", _analytic_beam_constructor
+)
+
+
+def declared_beam_type(config_path: Path) -> str | None:
+    """Return the canonical beam-type label a pyuvsim telescope config
+    declares (e.g. "gaussian", "airy"), or None if it can't be determined.
+    """
+
+    try:
+        with config_path.open(encoding="utf-8") as fh:
+            values = yaml.load(fh, Loader=_SafeLoaderWithAnalyticBeamTag)
+    except Exception:
+        return None
+
+    if not isinstance(values, dict):
+        return None
+
+    beam_paths = values.get("beam_paths")
+    if not isinstance(beam_paths, dict) or 0 not in beam_paths:
+        return None
+
+    beam_entry = beam_paths[0]
+    if not isinstance(beam_entry, dict):
+        return None
+
+    raw_label = beam_entry.get("class") or beam_entry.get("type")
+    if not isinstance(raw_label, str):
+        return None
+
+    return _CONFIG_TYPE_LABELS.get(raw_label.strip().lower())
+
+
+def path_claimed_beam_types(path: Path) -> set[str]:
+    """Beam-type keywords found directly in the file's own name."""
+
+    tokens = {
+        token.lower() for token in _TOKEN_SPLIT_RE.split(path.name) if token
+    }
+    return {
+        label
+        for keyword, label in _PATH_LABEL_KEYWORDS.items()
+        if keyword in tokens
+    }
+
+
+def find_cited_telescope_configs(history: str) -> list[str]:
+    """Telescope-config filenames referenced in a UVH5 history string."""
+
+    return _TELESCOPE_CONFIG_RE.findall(history or "")
+
+
+def locate_config(filename: str, search_dirs: tuple[Path, ...]) -> Path | None:
+    for search_dir in search_dirs:
+        candidate = search_dir / filename
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+@register_check("metadata_summary", CheckTier.FAST)
+def check_metadata_summary(ctx: CheckContext) -> CheckResult:
+    """Always-informational dump of key header fields. Never fails."""
+
+    header = ctx.header
+    details = {
+        "nants_telescope": header.get("nants_telescope"),
+        "nants_data": header.get("nants_data"),
+        "nbls": header.get("nbls"),
+        "ntimes": header.get("ntimes"),
+        "nfreqs": header.get("nfreqs"),
+        "npols": header.get("npols"),
+        "vis_units": header.get("vis_units"),
+        "byte_size": header.get("byte_size"),
+        "history_tail": (header.get("history") or "")[-500:],
+    }
+    return CheckResult(
+        check_id="metadata_summary",
+        status=CheckStatus.PASS,
+        message="metadata read successfully",
+        details=details,
+    )
+
+
+@register_check("beam_type_consistency", CheckTier.FAST)
+def check_beam_type_consistency(ctx: CheckContext) -> CheckResult:
+    """Does this file's own name agree with what its cited telescope
+    config actually declares as the beam type?
+
+    This is the check that would have caught the incident this module
+    exists because of: a file named with "airy" whose cited
+    telescope_config actually declared a Gaussian beam.
+    """
+
+    history = ctx.header.get("history") or ""
+    cited = find_cited_telescope_configs(history)
+    claimed = path_claimed_beam_types(ctx.path)
+
+    if not cited:
+        return CheckResult(
+            check_id="beam_type_consistency",
+            status=CheckStatus.SKIP,
+            message="no telescope_config reference found in history",
+            details={"path_claimed_beam_types": sorted(claimed)},
+        )
+
+    resolved: dict[str, str | None] = {}
+    located: dict[str, str] = {}
+    for filename in cited:
+        config_path = locate_config(filename, ctx.config_search_dirs)
+        if config_path is None:
+            resolved[filename] = None
+            continue
+        located[filename] = str(config_path)
+        resolved[filename] = declared_beam_type(config_path)
+
+    unresolved = [name for name, label in resolved.items() if label is None]
+    resolved_labels = {
+        label for label in resolved.values() if label is not None
+    }
+
+    details = {
+        "cited_configs": cited,
+        "located_configs": located,
+        "declared_beam_types": resolved,
+        "path_claimed_beam_types": sorted(claimed),
+    }
+
+    if not resolved_labels:
+        return CheckResult(
+            check_id="beam_type_consistency",
+            status=CheckStatus.WARN,
+            message=(
+                "history cites telescope config(s) "
+                f"{cited} but none could be located/parsed in the "
+                "configured search directories; declared beam type "
+                "unknown"
+            ),
+            details=details,
+        )
+
+    if len(resolved_labels) > 1:
+        return CheckResult(
+            check_id="beam_type_consistency",
+            status=CheckStatus.WARN,
+            message=(
+                "history cites telescope configs with conflicting "
+                f"declared beam types: {resolved}"
+            ),
+            details=details,
+        )
+
+    declared = next(iter(resolved_labels))
+
+    if claimed and declared not in claimed:
+        return CheckResult(
+            check_id="beam_type_consistency",
+            status=CheckStatus.FAIL,
+            message=(
+                f"file name claims beam type(s) {sorted(claimed)}, but "
+                f"its cited telescope config actually declares "
+                f"'{declared}'"
+            ),
+            details=details,
+        )
+
+    if ctx.expected_beam_type and declared != ctx.expected_beam_type:
+        return CheckResult(
+            check_id="beam_type_consistency",
+            status=CheckStatus.FAIL,
+            message=(
+                f"cited telescope config declares beam type "
+                f"'{declared}', which does not match the expected "
+                f"beam type '{ctx.expected_beam_type}'"
+            ),
+            details=details,
+        )
+
+    if unresolved:
+        return CheckResult(
+            check_id="beam_type_consistency",
+            status=CheckStatus.WARN,
+            message=(
+                f"declared beam type '{declared}' is consistent with "
+                f"available evidence, but config(s) {unresolved} could "
+                "not be located to fully confirm"
+            ),
+            details=details,
+        )
+
+    return CheckResult(
+        check_id="beam_type_consistency",
+        status=CheckStatus.PASS,
+        message=f"declared beam type '{declared}' is consistent",
+        details=details,
+    )

--- a/src/valska/data_preflight/checks.py
+++ b/src/valska/data_preflight/checks.py
@@ -147,7 +147,7 @@ def check_metadata_summary(ctx: CheckContext) -> CheckResult:
     that is missing from the header entirely. A field with an
     unreadable/non-numeric value causes ``read_uvh5_header`` itself to
     raise, which is surfaced as a file-level read error rather than a
-    WARN/FAIL from this check.
+    FAIL from this check.
     """
 
     header = ctx.header
@@ -171,9 +171,9 @@ def check_metadata_summary(ctx: CheckContext) -> CheckResult:
     if missing:
         return CheckResult(
             check_id="metadata_summary",
-            status=CheckStatus.WARN,
+            status=CheckStatus.FAIL,
             message=(
-                "header is missing expected field(s): " + ", ".join(missing)
+                "header is missing required field(s): " + ", ".join(missing)
             ),
             details=details,
         )

--- a/src/valska/data_preflight/checks.py
+++ b/src/valska/data_preflight/checks.py
@@ -127,9 +127,28 @@ def locate_config(filename: str, search_dirs: tuple[Path, ...]) -> Path | None:
     return None
 
 
+_REQUIRED_METADATA_FIELDS = (
+    "nants_telescope",
+    "nants_data",
+    "nbls",
+    "ntimes",
+    "nfreqs",
+    "npols",
+    "vis_units",
+)
+
+
 @register_check("metadata_summary", CheckTier.FAST)
 def check_metadata_summary(ctx: CheckContext) -> CheckResult:
-    """Always-informational dump of key header fields. Never fails."""
+    """Report key ``/Header`` fields, flagging any that are absent.
+
+    This reports on what ``inspect.read_uvh5_header`` already found; it
+    cannot detect a header field that is present but wrong, only one
+    that is missing from the header entirely. A field with an
+    unreadable/non-numeric value causes ``read_uvh5_header`` itself to
+    raise, which is surfaced as a file-level read error rather than a
+    WARN/FAIL from this check.
+    """
 
     header = ctx.header
     details = {
@@ -143,27 +162,60 @@ def check_metadata_summary(ctx: CheckContext) -> CheckResult:
         "byte_size": header.get("byte_size"),
         "history_tail": (header.get("history") or "")[-500:],
     }
+
+    missing = [
+        field_name
+        for field_name in _REQUIRED_METADATA_FIELDS
+        if header.get(field_name) is None
+    ]
+    if missing:
+        return CheckResult(
+            check_id="metadata_summary",
+            status=CheckStatus.WARN,
+            message=(
+                "header is missing expected field(s): " + ", ".join(missing)
+            ),
+            details=details,
+        )
+
     return CheckResult(
         check_id="metadata_summary",
         status=CheckStatus.PASS,
-        message="metadata read successfully",
+        message="all expected header fields are present",
         details=details,
     )
 
 
 @register_check("beam_type_consistency", CheckTier.FAST)
 def check_beam_type_consistency(ctx: CheckContext) -> CheckResult:
-    """Does this file's own name agree with what its cited telescope
-    config actually declares as the beam type?
+    """Does this file's own name agree with the beam type declared by
+    the telescope config its recorded history cites?
 
-    This is the check that would have caught the incident this module
-    exists because of: a file named with "airy" whose cited
-    telescope_config actually declared a Gaussian beam.
+    This compares two pieces of recorded metadata (the filename and the
+    history-cited config's declared beam type) for consistency. It is a
+    provenance-consistency check, not proof of what the file's data
+    actually contain: the history string may itself be inaccurate or
+    stale, and a config file located by name in the search directories
+    may not be byte-identical to whatever was in effect at simulation
+    time. Agreement between the two is useful supporting evidence, not
+    a guarantee; disagreement is a strong, actionable signal to
+    investigate before using the file.
     """
 
     history = ctx.header.get("history") or ""
     cited = find_cited_telescope_configs(history)
     claimed = path_claimed_beam_types(ctx.path)
+
+    if len(claimed) > 1:
+        return CheckResult(
+            check_id="beam_type_consistency",
+            status=CheckStatus.FAIL,
+            message=(
+                f"file name claims multiple distinct beam types "
+                f"{sorted(claimed)}, which is internally inconsistent"
+            ),
+            details={"path_claimed_beam_types": sorted(claimed)},
+        )
 
     if not cited:
         return CheckResult(
@@ -227,8 +279,7 @@ def check_beam_type_consistency(ctx: CheckContext) -> CheckResult:
             status=CheckStatus.FAIL,
             message=(
                 f"file name claims beam type(s) {sorted(claimed)}, but "
-                f"its cited telescope config actually declares "
-                f"'{declared}'"
+                f"its cited telescope config declares '{declared}'"
             ),
             details=details,
         )
@@ -250,9 +301,9 @@ def check_beam_type_consistency(ctx: CheckContext) -> CheckResult:
             check_id="beam_type_consistency",
             status=CheckStatus.WARN,
             message=(
-                f"declared beam type '{declared}' is consistent with "
-                f"available evidence, but config(s) {unresolved} could "
-                "not be located to fully confirm"
+                f"file name and the located config(s) agree on beam "
+                f"type '{declared}', but config(s) {unresolved} cited "
+                "in the history could not be located to check as well"
             ),
             details=details,
         )
@@ -260,6 +311,9 @@ def check_beam_type_consistency(ctx: CheckContext) -> CheckResult:
     return CheckResult(
         check_id="beam_type_consistency",
         status=CheckStatus.PASS,
-        message=f"declared beam type '{declared}' is consistent",
+        message=(
+            f"file name and its cited telescope config agree on beam "
+            f"type '{declared}'"
+        ),
         details=details,
     )

--- a/src/valska/data_preflight/cli.py
+++ b/src/valska/data_preflight/cli.py
@@ -40,6 +40,7 @@ _STATUS_ORDER = {
     CheckStatus.SKIP: 2,
     CheckStatus.PASS: 3,
 }
+_JSON_SCHEMA_VERSION = 1
 
 
 def default_config_search_dirs() -> tuple[Path, ...]:
@@ -221,6 +222,19 @@ def _print_text(reports: list[dict[str, Any]]) -> None:
             print(f"  - {path}")
 
 
+def _print_json(missing: list[Path], reports: list[dict[str, Any]]) -> None:
+    print(
+        json.dumps(
+            {
+                "schema_version": _JSON_SCHEMA_VERSION,
+                "missing_paths": [str(path) for path in missing],
+                "reports": reports,
+            },
+            indent=2,
+        )
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the CLI.
 
@@ -254,6 +268,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: input path does not exist: {path}", file=sys.stderr)
 
     if not files:
+        if args.json_out:
+            _print_json(missing, [])
         if missing:
             return 3
         print(
@@ -273,15 +289,7 @@ def main(argv: list[str] | None = None) -> int:
     ]
 
     if args.json_out:
-        print(
-            json.dumps(
-                {
-                    "missing_paths": [str(p) for p in missing],
-                    "reports": reports,
-                },
-                indent=2,
-            )
-        )
+        _print_json(missing, reports)
     else:
         _print_text(reports)
 

--- a/src/valska/data_preflight/cli.py
+++ b/src/valska/data_preflight/cli.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Pre-flight inspection of UVH5 data files.
+
+Runs cheap consistency checks (currently: does a file's name agree with
+what its cited telescope config actually declares as the beam type)
+against one or more files, or every ``*.uvh5`` file under a directory,
+before they are used in an expensive analysis.
+
+This is advisory only: it reports findings and, by default, always
+exits 0. Pass --strict to exit non-zero when any check FAILs, e.g. for
+use as a script-level gate later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from valska.data_preflight.inspect import read_uvh5_header
+from valska.data_preflight.registry import (
+    CheckContext,
+    CheckStatus,
+    CheckTier,
+    run_checks,
+)
+
+_STATUS_ORDER = {
+    CheckStatus.FAIL: 0,
+    CheckStatus.WARN: 1,
+    CheckStatus.SKIP: 2,
+    CheckStatus.PASS: 3,
+}
+
+
+def default_config_search_dirs() -> tuple[Path, ...]:
+    """Directories to search for telescope configs cited in a file's
+    history, by default: this repo's own shipped pyuvsim telescope
+    configs.
+    """
+
+    try:
+        import valska.external_tools.pyuvsim as pyuvsim_pkg
+
+        templates_dir = Path(pyuvsim_pkg.__file__).parent / "templates"
+        return (templates_dir / "telescope_config", templates_dir)
+    except Exception:
+        return ()
+
+
+def discover_uvh5_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.uvh5")))
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def inspect_file(
+    path: Path,
+    *,
+    config_search_dirs: tuple[Path, ...],
+    expected_beam_type: str | None,
+    tiers: tuple[CheckTier, ...],
+) -> dict[str, Any]:
+    try:
+        header = read_uvh5_header(path)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "path": str(path),
+            "error": f"failed to read header: {exc}",
+            "checks": [],
+        }
+
+    ctx = CheckContext(
+        path=path,
+        header=header,
+        config_search_dirs=config_search_dirs,
+        expected_beam_type=expected_beam_type,
+    )
+    results = run_checks(ctx, tiers)
+    results.sort(key=lambda r: _STATUS_ORDER[r.status])
+    return {
+        "path": str(path),
+        "error": None,
+        "checks": [r.to_dict() for r in results],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="valska-data-preflight",
+        description=(
+            "Run cheap pre-flight consistency checks against UVH5 data "
+            "files before using them in an expensive analysis."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  valska-data-preflight path/to/file.uvh5\n"
+            "  valska-data-preflight path/to/file.uvh5 "
+            "--expected-beam-type airy\n"
+            "  valska-data-preflight path/to/directory --json\n"
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="One or more UVH5 files, or directories to scan recursively.",
+    )
+    parser.add_argument(
+        "--config-search-dir",
+        dest="config_search_dirs",
+        action="append",
+        type=Path,
+        default=None,
+        help=(
+            "Additional directory to search for telescope configs cited "
+            "in a file's history. May be repeated. Added to (not "
+            "replacing) the built-in default search directories."
+        ),
+    )
+    parser.add_argument(
+        "--expected-beam-type",
+        default=None,
+        choices=["gaussian", "airy", "uniform", "short_dipole"],
+        help=(
+            "If given, flag any file whose cited config declares a "
+            "different beam type. Most useful in single-file mode."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_out",
+        action="store_true",
+        help="Print machine-readable JSON payload instead of text.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Exit with a non-zero status if any check result is FAIL. "
+            "Default is advisory-only: always exits 0 (I/O errors "
+            "aside)."
+        ),
+    )
+    return parser
+
+
+def _print_text(reports: list[dict[str, Any]]) -> None:
+    counts = {status.value: 0 for status in CheckStatus}
+    flagged: list[str] = []
+
+    for report in reports:
+        print(f"=== {report['path']} ===")
+        if report["error"]:
+            print(f"  ERROR: {report['error']}")
+            continue
+        for check in report["checks"]:
+            status = check["status"]
+            counts[status] += 1
+            print(
+                f"  {check['check_id']}: {status.upper()} - {check['message']}"
+            )
+            for key, value in check["details"].items():
+                if key == "history_tail":
+                    continue
+                print(f"      {key}: {value}")
+        if any(c["status"] in ("fail", "warn") for c in report["checks"]):
+            flagged.append(report["path"])
+
+    print()
+    print(
+        "Summary: " + ", ".join(f"{k.upper()}={v}" for k, v in counts.items())
+    )
+    if flagged:
+        print(f"Files with FAIL or WARN ({len(flagged)}):")
+        for path in flagged:
+            print(f"  - {path}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    search_dirs = default_config_search_dirs()
+    if args.config_search_dirs:
+        search_dirs = tuple(args.config_search_dirs) + search_dirs
+
+    files = discover_uvh5_files(args.paths)
+    if not files:
+        print(
+            "ERROR: no .uvh5 files found among the given paths",
+            file=sys.stderr,
+        )
+        return 2
+
+    reports = [
+        inspect_file(
+            path,
+            config_search_dirs=search_dirs,
+            expected_beam_type=args.expected_beam_type,
+            tiers=(CheckTier.FAST,),
+        )
+        for path in files
+    ]
+
+    if args.json_out:
+        print(json.dumps(reports, indent=2))
+    else:
+        _print_text(reports)
+
+    if args.strict:
+        any_fail = any(
+            check["status"] == "fail"
+            for report in reports
+            for check in report["checks"]
+        ) or any(report["error"] for report in reports)
+        if any_fail:
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/valska/data_preflight/cli.py
+++ b/src/valska/data_preflight/cli.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
 """Pre-flight inspection of UVH5 data files.
 
-Runs cheap consistency checks (currently: does a file's name agree with
-what its cited telescope config actually declares as the beam type)
-against one or more files, or every ``*.uvh5`` file under a directory,
-before they are used in an expensive analysis.
+Runs cheap metadata/provenance-consistency checks (currently: does a
+file's name agree with the beam type declared by the telescope config
+its cited history references) against one or more files, or every
+``*.uvh5`` file under a directory, before they are used in an
+expensive analysis.
 
-This is advisory only: it reports findings and, by default, always
-exits 0. Pass --strict to exit non-zero when any check FAILs, e.g. for
-use as a script-level gate later.
+These checks compare recorded metadata against itself; they cannot
+confirm what a file's data actually contain, only whether its recorded
+provenance is internally consistent.
+
+The scientific checks are advisory only: by default, a run always
+exits 0 regardless of PASS/WARN/FAIL/SKIP results, unless --strict is
+passed, which exits non-zero if any check FAILed. Input-discovery and
+file-read failures are a separate matter and always cause a non-zero
+exit, independent of --strict; see ``main`` for the exact exit codes.
 """
 
 from __future__ import annotations
@@ -50,14 +57,42 @@ def default_config_search_dirs() -> tuple[Path, ...]:
         return ()
 
 
-def discover_uvh5_files(paths: list[Path]) -> list[Path]:
+def discover_uvh5_files(
+    paths: list[Path],
+) -> tuple[list[Path], list[Path]]:
+    """Resolve requested paths to concrete ``.uvh5`` files.
+
+    Returns ``(files, missing)``: ``missing`` lists any requested path
+    that is neither an existing file nor an existing directory, in the
+    order given. A requested path that is an existing but empty
+    directory (or one with no ``.uvh5`` files) is not "missing" — it
+    was found, it simply contributed no files.
+
+    A file reachable via more than one requested path (passed
+    directly and also matched by scanning a parent directory, or
+    passed twice) is only included once, keeping first-seen order.
+    """
+
     files: list[Path] = []
+    seen: set[Path] = set()
+    missing: list[Path] = []
+
+    def _add(candidate: Path) -> None:
+        resolved = candidate.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            files.append(candidate)
+
     for path in paths:
         if path.is_dir():
-            files.extend(sorted(path.rglob("*.uvh5")))
+            for found in sorted(path.rglob("*.uvh5")):
+                _add(found)
         elif path.is_file():
-            files.append(path)
-    return files
+            _add(path)
+        else:
+            missing.append(path)
+
+    return files, missing
 
 
 def inspect_file(
@@ -144,9 +179,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--strict",
         action="store_true",
         help=(
-            "Exit with a non-zero status if any check result is FAIL. "
-            "Default is advisory-only: always exits 0 (I/O errors "
-            "aside)."
+            "Exit 1 if any scientific check result is FAIL. Default "
+            "is advisory-only for scientific checks (always exits 0 "
+            "for them). Missing input paths or file-read failures "
+            "always cause a non-zero exit (2 or 3) regardless of "
+            "--strict; see the CLI documentation for exact codes."
         ),
     )
     return parser
@@ -185,14 +222,40 @@ def _print_text(reports: list[dict[str, Any]]) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the CLI.
+
+    Exit codes:
+
+    - ``0`` — clean run: every requested path existed, every
+      discovered file was read successfully, and (if ``--strict``)
+      no check FAILed.
+    - ``1`` — ``--strict`` was passed and at least one scientific
+      check FAILed. Only checked when there were no missing paths or
+      read errors (those take precedence, below).
+    - ``2`` — every requested path existed, but none contained (or
+      was) a ``.uvh5`` file, so there was nothing to check.
+    - ``3`` — one or more requested paths did not exist, and/or one
+      or more discovered files failed to read. This is independent
+      of ``--strict``: it reflects a problem finding or reading
+      inputs, not a scientific check outcome. Other requested paths
+      that did exist, and other files that did read successfully,
+      are still processed and reported.
+    """
+
     args = build_parser().parse_args(argv)
 
     search_dirs = default_config_search_dirs()
     if args.config_search_dirs:
         search_dirs = tuple(args.config_search_dirs) + search_dirs
 
-    files = discover_uvh5_files(args.paths)
+    files, missing = discover_uvh5_files(args.paths)
+
+    for path in missing:
+        print(f"ERROR: input path does not exist: {path}", file=sys.stderr)
+
     if not files:
+        if missing:
+            return 3
         print(
             "ERROR: no .uvh5 files found among the given paths",
             file=sys.stderr,
@@ -210,16 +273,28 @@ def main(argv: list[str] | None = None) -> int:
     ]
 
     if args.json_out:
-        print(json.dumps(reports, indent=2))
+        print(
+            json.dumps(
+                {
+                    "missing_paths": [str(p) for p in missing],
+                    "reports": reports,
+                },
+                indent=2,
+            )
+        )
     else:
         _print_text(reports)
+
+    read_errors = any(report["error"] for report in reports)
+    if missing or read_errors:
+        return 3
 
     if args.strict:
         any_fail = any(
             check["status"] == "fail"
             for report in reports
             for check in report["checks"]
-        ) or any(report["error"] for report in reports)
+        )
         if any_fail:
             return 1
 

--- a/src/valska/data_preflight/inspect.py
+++ b/src/valska/data_preflight/inspect.py
@@ -1,0 +1,52 @@
+"""Cheap, header-only inspection of UVH5 files.
+
+Deliberately reads only the ``/Header`` group via h5py rather than a
+full ``pyuvdata.UVData.read_uvh5``, so this stays fast enough to run
+before every analysis, on files of any size.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+
+_SCALAR_INT_FIELDS = (
+    "Nants_telescope",
+    "Nants_data",
+    "Nbls",
+    "Ntimes",
+    "Nfreqs",
+    "Npols",
+)
+_STRING_FIELDS = ("history", "vis_units")
+
+
+def _decode(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def read_uvh5_header(path: Path) -> dict[str, Any]:
+    """Read key ``/Header`` fields from a UVH5 file without touching data.
+
+    Returns a plain dict with lowercase, snake_case-ish keys (matching
+    what the checks in this package expect), plus ``byte_size`` from the
+    filesystem.
+    """
+
+    path = Path(path)
+    result: dict[str, Any] = {"byte_size": path.stat().st_size}
+
+    with h5py.File(path, "r") as handle:
+        header = handle["Header"]
+        for field_name in _SCALAR_INT_FIELDS:
+            if field_name in header:
+                result[field_name.lower()] = int(header[field_name][()])
+        for field_name in _STRING_FIELDS:
+            if field_name in header:
+                result[field_name.lower()] = _decode(header[field_name][()])
+
+    return result

--- a/src/valska/data_preflight/registry.py
+++ b/src/valska/data_preflight/registry.py
@@ -1,0 +1,161 @@
+"""Check registry: the extensibility mechanism for pre-flight checks.
+
+Each check is a small function registered against a tier. Checks are
+looked up and run by tier so a caller can choose how much to run (e.g.
+"only the free/fast checks" vs "everything available").
+"""
+
+from __future__ import annotations
+
+import traceback
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class CheckStatus(Enum):
+    """Outcome of a single check."""
+
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
+class CheckTier(Enum):
+    """Cost/availability tier a check belongs to.
+
+    FAST checks only read file headers/metadata and never need a second
+    file; they are cheap enough to always run. REFERENCE checks compare
+    against a designated "known good" file and are skipped automatically
+    when no reference is available. DEEP checks are more expensive
+    (curve fits, delay-domain transforms) and are opt-in.
+    """
+
+    FAST = "fast"
+    REFERENCE = "reference"
+    DEEP = "deep"
+
+
+@dataclass
+class CheckResult:
+    """The outcome of running one check against one file."""
+
+    check_id: str
+    status: CheckStatus
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "check_id": self.check_id,
+            "status": self.status.value,
+            "message": self.message,
+            "details": self.details,
+        }
+
+
+@dataclass
+class CheckContext:
+    """Input shared by all checks run against a single file.
+
+    ``header`` and ``config_search_dirs`` are provided up front so
+    individual checks don't each re-implement file reading or config
+    discovery; checks that need more than this should read additional
+    data themselves and cache it on ``extra``.
+    """
+
+    path: Path
+    header: dict[str, Any]
+    config_search_dirs: tuple[Path, ...] = ()
+    reference_path: Path | None = None
+    expected_beam_type: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+CheckFunc = Callable[[CheckContext], CheckResult]
+
+_REGISTRY: dict[str, tuple[CheckFunc, CheckTier]] = {}
+
+
+def register_check(
+    check_id: str, tier: CheckTier
+) -> Callable[[CheckFunc], CheckFunc]:
+    """Decorator registering a function as a named, tiered check.
+
+    Parameters
+    ----------
+    check_id :
+        Stable identifier for this check, used in reports and to
+        select/exclude checks. Must be unique across the registry.
+    tier :
+        Cost/availability tier this check belongs to.
+    """
+
+    def decorator(func: CheckFunc) -> CheckFunc:
+        if check_id in _REGISTRY:
+            raise ValueError(f"duplicate check_id: {check_id!r}")
+        _REGISTRY[check_id] = (func, tier)
+        return func
+
+    return decorator
+
+
+def _ensure_builtin_checks_imported() -> None:
+    # Importing this module runs its @register_check decorators. Done
+    # lazily (rather than at package import time) to avoid import-order
+    # issues between registry.py and checks.py.
+    import valska.data_preflight.checks  # noqa: F401
+
+
+def list_checks(
+    tiers: Iterable[CheckTier] | None = None,
+) -> list[tuple[str, CheckTier]]:
+    """List registered check IDs and their tiers, optionally filtered."""
+
+    _ensure_builtin_checks_imported()
+    tier_set = set(tiers) if tiers is not None else None
+    return [
+        (check_id, tier)
+        for check_id, (_func, tier) in _REGISTRY.items()
+        if tier_set is None or tier in tier_set
+    ]
+
+
+def run_checks(
+    ctx: CheckContext,
+    tiers: Iterable[CheckTier],
+    *,
+    check_ids: Iterable[str] | None = None,
+) -> list[CheckResult]:
+    """Run every registered check in the requested tier(s) against ``ctx``.
+
+    A check that raises is recorded as a FAIL rather than propagating,
+    so one broken check cannot prevent the rest of the report from
+    being produced.
+    """
+
+    _ensure_builtin_checks_imported()
+    tier_set = set(tiers)
+    id_filter = set(check_ids) if check_ids is not None else None
+
+    results: list[CheckResult] = []
+    for check_id, (func, tier) in _REGISTRY.items():
+        if tier not in tier_set:
+            continue
+        if id_filter is not None and check_id not in id_filter:
+            continue
+        try:
+            results.append(func(ctx))
+        except Exception as exc:  # noqa: BLE001
+            results.append(
+                CheckResult(
+                    check_id=check_id,
+                    status=CheckStatus.FAIL,
+                    message=f"check raised an exception: {exc}",
+                    details={"traceback": traceback.format_exc()},
+                )
+            )
+    return results

--- a/tests/test_data_preflight.py
+++ b/tests/test_data_preflight.py
@@ -1,0 +1,443 @@
+"""Tests for the data_preflight pre-flight check package."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import h5py
+import pytest
+
+from valska.data_preflight import checks as checks_module
+from valska.data_preflight.cli import (
+    build_parser,
+    default_config_search_dirs,
+    discover_uvh5_files,
+    inspect_file,
+    main,
+)
+from valska.data_preflight.inspect import read_uvh5_header
+from valska.data_preflight.registry import (
+    CheckContext,
+    CheckResult,
+    CheckStatus,
+    CheckTier,
+    list_checks,
+    register_check,
+    run_checks,
+)
+
+# ---------------------------------------------------------------------
+# registry.py
+# ---------------------------------------------------------------------
+
+
+def test_register_check_rejects_duplicate_ids() -> None:
+    @register_check("test_dup_check_unique_name", CheckTier.FAST)
+    def _first(ctx: CheckContext) -> CheckResult:
+        return CheckResult(
+            "test_dup_check_unique_name", CheckStatus.PASS, "ok"
+        )
+
+    with pytest.raises(ValueError, match="duplicate check_id"):
+
+        @register_check("test_dup_check_unique_name", CheckTier.FAST)
+        def _second(ctx: CheckContext) -> CheckResult:
+            return CheckResult(
+                "test_dup_check_unique_name", CheckStatus.PASS, "ok"
+            )
+
+
+def test_list_checks_includes_builtins() -> None:
+    fast_checks = {
+        check_id for check_id, tier in list_checks([CheckTier.FAST])
+    }
+    assert "metadata_summary" in fast_checks
+    assert "beam_type_consistency" in fast_checks
+
+
+def test_run_checks_filters_by_tier() -> None:
+    ctx = CheckContext(path=Path("dummy.uvh5"), header={})
+    results = run_checks(ctx, [CheckTier.REFERENCE])
+    assert results == []
+
+
+def test_run_checks_catches_exceptions_as_fail() -> None:
+    check_id = "test_exploding_check"
+
+    @register_check(check_id, CheckTier.FAST)
+    def _explode(ctx: CheckContext) -> CheckResult:
+        raise RuntimeError("boom")
+
+    ctx = CheckContext(path=Path("dummy.uvh5"), header={})
+    results = run_checks(ctx, [CheckTier.FAST], check_ids=[check_id])
+    assert len(results) == 1
+    assert results[0].status is CheckStatus.FAIL
+    assert "boom" in results[0].message
+
+
+# ---------------------------------------------------------------------
+# checks.py
+# ---------------------------------------------------------------------
+
+
+def _write_config(path: Path, beam_type: str, **extra: object) -> None:
+    lines = [
+        "beam_paths:",
+        "  0:",
+        f"    type: '{beam_type}'",
+    ]
+    for key, value in extra.items():
+        lines.append(f"    {key}: {value}")
+    lines.append(
+        "telescope_location: "
+        "(-30.72152777777791, 21.428305555555557, 1073.0000000093132)"
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_declared_beam_type_reads_gaussian(tmp_path: Path) -> None:
+    config = tmp_path / "hex-37-gauss.yml"
+    _write_config(config, "gaussian", sigma=0.0975)
+    assert checks_module.declared_beam_type(config) == "gaussian"
+
+
+def test_declared_beam_type_reads_airy(tmp_path: Path) -> None:
+    config = tmp_path / "hex-37-airy.yml"
+    _write_config(config, "airy", diameter=14.0)
+    assert checks_module.declared_beam_type(config) == "airy"
+
+
+def test_declared_beam_type_returns_none_for_missing_file(
+    tmp_path: Path,
+) -> None:
+    assert checks_module.declared_beam_type(tmp_path / "missing.yml") is None
+
+
+def test_declared_beam_type_returns_none_for_malformed_yaml(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "bad.yml"
+    config.write_text("not: [valid, beam, config", encoding="utf-8")
+    assert checks_module.declared_beam_type(config) is None
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        # Regression case: this is the exact real-world pattern that a
+        # naive \b-boundary regex fails on, because "_" is a \w
+        # character and so does not form a boundary against "airy".
+        ("gsm_plus_gleam-...-airy_quentin.uvh5", {"airy"}),
+        ("hex-37-14.6m-gauss-fwhm9.3.yml", {"gaussian"}),
+        ("gsm_plus_gleam-...-airy_quentin_ref.uvh5", {"airy"}),
+        ("plain_file_with_no_beam_keyword.uvh5", set()),
+        # "hairy" should not be mistaken for "airy".
+        ("some_hairy_dataset.uvh5", set()),
+    ],
+)
+def test_path_claimed_beam_types(filename: str, expected: set[str]) -> None:
+    assert checks_module.path_claimed_beam_types(Path(filename)) == expected
+
+
+def test_find_cited_telescope_configs() -> None:
+    history = (
+        "Based on config files: fov-19.4-oscar-sm.yml, "
+        "telescope_config/hex-37-14.6m-gauss-fwhm9.3.yml, "
+        "telescope_config/hex-37-14.6m.csv Npus = 8."
+    )
+    assert checks_module.find_cited_telescope_configs(history) == [
+        "hex-37-14.6m-gauss-fwhm9.3.yml"
+    ]
+
+
+def test_locate_config_searches_in_order(tmp_path: Path) -> None:
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    (dir_b / "hex.yml").write_text("beam_paths: {}", encoding="utf-8")
+
+    found = checks_module.locate_config("hex.yml", (dir_a, dir_b))
+    assert found == dir_b / "hex.yml"
+
+    assert checks_module.locate_config("missing.yml", (dir_a, dir_b)) is None
+
+
+def _ctx_for_history(
+    path: Path, history: str, config_search_dirs: tuple[Path, ...] = ()
+) -> CheckContext:
+    return CheckContext(
+        path=path,
+        header={"history": history},
+        config_search_dirs=config_search_dirs,
+    )
+
+
+def test_beam_type_consistency_fails_on_real_incident_pattern(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "telescope_config"
+    config_dir.mkdir()
+    _write_config(
+        config_dir / "hex-37-14.6m-gauss-fwhm9.3.yml", "gaussian", sigma=0.0975
+    )
+
+    path = tmp_path / "gsm_plus_gleam-airy_quentin.uvh5"
+    ctx = _ctx_for_history(
+        path,
+        "Based on config files: telescope_config/hex-37-14.6m-gauss-fwhm9.3.yml",
+        config_search_dirs=(config_dir,),
+    )
+
+    result = checks_module.check_beam_type_consistency(ctx)
+    assert result.status is CheckStatus.FAIL
+    assert "gaussian" in result.message
+    assert "airy" in result.message
+
+
+def test_beam_type_consistency_passes_when_consistent(tmp_path: Path) -> None:
+    config_dir = tmp_path / "telescope_config"
+    config_dir.mkdir()
+    _write_config(config_dir / "hex-37-airy.yml", "airy", diameter=14.0)
+
+    path = tmp_path / "gsm_plus_gleam-airy_quentin.uvh5"
+    ctx = _ctx_for_history(
+        path,
+        "Based on config files: telescope_config/hex-37-airy.yml",
+        config_search_dirs=(config_dir,),
+    )
+
+    result = checks_module.check_beam_type_consistency(ctx)
+    assert result.status is CheckStatus.PASS
+
+
+def test_beam_type_consistency_warns_when_config_not_locatable(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "gsm_plus_gleam-airy_quentin_ref.uvh5"
+    ctx = _ctx_for_history(
+        path,
+        "Based on config files: telescope_config/hex-37-14.6m-perturbedairy.yml",
+        config_search_dirs=(),
+    )
+
+    result = checks_module.check_beam_type_consistency(ctx)
+    assert result.status is CheckStatus.WARN
+    assert "could be located/parsed" in result.message
+
+
+def test_beam_type_consistency_skips_when_no_history_citation(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "some_file.uvh5"
+    ctx = _ctx_for_history(path, "no config references here")
+
+    result = checks_module.check_beam_type_consistency(ctx)
+    assert result.status is CheckStatus.SKIP
+
+
+def test_beam_type_consistency_checks_expected_beam_type(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "telescope_config"
+    config_dir.mkdir()
+    _write_config(config_dir / "hex-37-gauss.yml", "gaussian", sigma=0.0975)
+
+    path = tmp_path / "plain_file.uvh5"
+    ctx = CheckContext(
+        path=path,
+        header={
+            "history": (
+                "Based on config files: telescope_config/hex-37-gauss.yml"
+            )
+        },
+        config_search_dirs=(config_dir,),
+        expected_beam_type="airy",
+    )
+
+    result = checks_module.check_beam_type_consistency(ctx)
+    assert result.status is CheckStatus.FAIL
+    assert "expected beam type 'airy'" in result.message
+
+
+def test_metadata_summary_reports_header_fields() -> None:
+    ctx = CheckContext(
+        path=Path("dummy.uvh5"),
+        header={
+            "nants_telescope": 37,
+            "nants_data": 13,
+            "nbls": 16,
+            "vis_units": "Jy",
+            "byte_size": 1499569,
+        },
+    )
+    result = checks_module.check_metadata_summary(ctx)
+    assert result.status is CheckStatus.PASS
+    assert result.details["nants_telescope"] == 37
+    assert result.details["vis_units"] == "Jy"
+
+
+# ---------------------------------------------------------------------
+# inspect.py
+# ---------------------------------------------------------------------
+
+
+def _write_minimal_uvh5_header(
+    path: Path,
+    *,
+    nants_telescope: int = 37,
+    nants_data: int = 13,
+    nbls: int = 16,
+    ntimes: int = 34,
+    nfreqs: int = 38,
+    npols: int = 4,
+    history: str = "test history",
+    vis_units: str = "Jy",
+) -> None:
+    with h5py.File(path, "w") as handle:
+        header = handle.create_group("Header")
+        header["Nants_telescope"] = nants_telescope
+        header["Nants_data"] = nants_data
+        header["Nbls"] = nbls
+        header["Ntimes"] = ntimes
+        header["Nfreqs"] = nfreqs
+        header["Npols"] = npols
+        header["history"] = history
+        header["vis_units"] = vis_units
+
+
+def test_read_uvh5_header_reads_expected_fields(tmp_path: Path) -> None:
+    path = tmp_path / "test.uvh5"
+    _write_minimal_uvh5_header(path, history="hello world")
+
+    header = read_uvh5_header(path)
+    assert header["nants_telescope"] == 37
+    assert header["nants_data"] == 13
+    assert header["nbls"] == 16
+    assert header["ntimes"] == 34
+    assert header["nfreqs"] == 38
+    assert header["npols"] == 4
+    assert header["history"] == "hello world"
+    assert header["vis_units"] == "Jy"
+    assert header["byte_size"] == path.stat().st_size
+
+
+# ---------------------------------------------------------------------
+# cli.py
+# ---------------------------------------------------------------------
+
+
+def test_default_config_search_dirs_includes_real_templates() -> None:
+    dirs = default_config_search_dirs()
+    assert any(d.name == "telescope_config" for d in dirs)
+
+
+def test_discover_uvh5_files_finds_files_in_directory(tmp_path: Path) -> None:
+    (tmp_path / "a.uvh5").touch()
+    (tmp_path / "b.uvh5").touch()
+    (tmp_path / "not_uvh5.txt").touch()
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.uvh5").touch()
+
+    found = discover_uvh5_files([tmp_path])
+    assert {f.name for f in found} == {"a.uvh5", "b.uvh5", "c.uvh5"}
+
+
+def test_discover_uvh5_files_accepts_direct_file(tmp_path: Path) -> None:
+    f = tmp_path / "single.uvh5"
+    f.touch()
+    assert discover_uvh5_files([f]) == [f]
+
+
+def test_inspect_file_reports_error_for_unreadable_file(
+    tmp_path: Path,
+) -> None:
+    bad = tmp_path / "not_actually_hdf5.uvh5"
+    bad.write_text("not an hdf5 file", encoding="utf-8")
+
+    report = inspect_file(
+        bad,
+        config_search_dirs=(),
+        expected_beam_type=None,
+        tiers=(CheckTier.FAST,),
+    )
+    assert report["error"] is not None
+    assert report["checks"] == []
+
+
+def test_main_end_to_end_flags_real_incident_pattern(
+    tmp_path: Path, capsys
+) -> None:
+    config_dir = tmp_path / "telescope_config"
+    config_dir.mkdir()
+    _write_config(config_dir / "hex-37-gauss.yml", "gaussian", sigma=0.0975)
+
+    uvh5_path = tmp_path / "gsm_plus_gleam-airy_quentin.uvh5"
+    _write_minimal_uvh5_header(
+        uvh5_path,
+        history=("Based on config files: telescope_config/hex-37-gauss.yml"),
+    )
+
+    code = main(
+        [
+            str(uvh5_path),
+            "--config-search-dir",
+            str(config_dir),
+            "--json",
+        ]
+    )
+    assert code == 0  # advisory by default, even on FAIL
+
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload) == 1
+    beam_check = next(
+        c
+        for c in payload[0]["checks"]
+        if c["check_id"] == "beam_type_consistency"
+    )
+    assert beam_check["status"] == "fail"
+
+
+def test_main_strict_exits_nonzero_on_fail(tmp_path: Path, capsys) -> None:
+    config_dir = tmp_path / "telescope_config"
+    config_dir.mkdir()
+    _write_config(config_dir / "hex-37-gauss.yml", "gaussian", sigma=0.0975)
+
+    uvh5_path = tmp_path / "gsm_plus_gleam-airy_quentin.uvh5"
+    _write_minimal_uvh5_header(
+        uvh5_path,
+        history=("Based on config files: telescope_config/hex-37-gauss.yml"),
+    )
+
+    code = main(
+        [
+            str(uvh5_path),
+            "--config-search-dir",
+            str(config_dir),
+            "--strict",
+            "--json",
+        ]
+    )
+    assert code == 1
+    capsys.readouterr()
+
+
+def test_main_returns_error_when_no_files_found(
+    tmp_path: Path, capsys
+) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    code = main([str(empty_dir)])
+    assert code == 2
+    captured = capsys.readouterr()
+    assert "no .uvh5 files found" in captured.err
+
+
+def test_build_parser_accepts_repeated_config_search_dir() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        ["file.uvh5", "--config-search-dir", "a", "--config-search-dir", "b"]
+    )
+    assert args.config_search_dirs == [Path("a"), Path("b")]

--- a/tests/test_data_preflight.py
+++ b/tests/test_data_preflight.py
@@ -134,6 +134,10 @@ def test_declared_beam_type_returns_none_for_malformed_yaml(
         ("plain_file_with_no_beam_keyword.uvh5", set()),
         # "hairy" should not be mistaken for "airy".
         ("some_hairy_dataset.uvh5", set()),
+        # A filename claiming two distinct beam types is internally
+        # inconsistent regardless of token order.
+        ("gsm_plus_gleam-airy_then_gauss.uvh5", {"airy", "gaussian"}),
+        ("gsm_plus_gleam-gauss_then_airy.uvh5", {"airy", "gaussian"}),
     ],
 )
 def test_path_claimed_beam_types(filename: str, expected: set[str]) -> None:
@@ -194,6 +198,37 @@ def test_beam_type_consistency_fails_on_real_incident_pattern(
     assert result.status is CheckStatus.FAIL
     assert "gaussian" in result.message
     assert "airy" in result.message
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "gsm_plus_gleam-airy_then_gauss.uvh5",
+        "gsm_plus_gleam-gauss_then_airy.uvh5",
+    ],
+)
+def test_beam_type_consistency_fails_on_ambiguous_filename_claim(
+    tmp_path: Path, filename: str
+) -> None:
+    # A filename claiming both "airy" and "gaussian" is internally
+    # inconsistent regardless of which declared type (or neither) the
+    # cited config turns out to have, and regardless of token order.
+    config_dir = tmp_path / "telescope_config"
+    config_dir.mkdir()
+    _write_config(config_dir / "hex-37-gauss.yml", "gaussian", sigma=0.0975)
+
+    path = tmp_path / filename
+    ctx = _ctx_for_history(
+        path,
+        "Based on config files: telescope_config/hex-37-gauss.yml",
+        config_search_dirs=(config_dir,),
+    )
+
+    result = checks_module.check_beam_type_consistency(ctx)
+    assert result.status is CheckStatus.FAIL
+    assert "airy" in result.message
+    assert "gaussian" in result.message
+    assert "multiple" in result.message
 
 
 def test_beam_type_consistency_passes_when_consistent(tmp_path: Path) -> None:
@@ -261,21 +296,51 @@ def test_beam_type_consistency_checks_expected_beam_type(
     assert "expected beam type 'airy'" in result.message
 
 
+def _complete_header(**overrides: object) -> dict[str, object]:
+    header: dict[str, object] = {
+        "nants_telescope": 37,
+        "nants_data": 13,
+        "nbls": 16,
+        "ntimes": 34,
+        "nfreqs": 38,
+        "npols": 4,
+        "vis_units": "Jy",
+        "byte_size": 1499569,
+        "history": "test history",
+    }
+    header.update(overrides)
+    return header
+
+
 def test_metadata_summary_reports_header_fields() -> None:
+    ctx = CheckContext(path=Path("dummy.uvh5"), header=_complete_header())
+    result = checks_module.check_metadata_summary(ctx)
+    assert result.status is CheckStatus.PASS
+    assert result.details["nants_telescope"] == 37
+    assert result.details["vis_units"] == "Jy"
+
+
+def test_metadata_summary_warns_on_incomplete_header() -> None:
+    # A header missing several expected fields (e.g. an older or
+    # partially-written file) should not be reported as a clean PASS.
     ctx = CheckContext(
         path=Path("dummy.uvh5"),
         header={
             "nants_telescope": 37,
             "nants_data": 13,
-            "nbls": 16,
-            "vis_units": "Jy",
             "byte_size": 1499569,
         },
     )
     result = checks_module.check_metadata_summary(ctx)
-    assert result.status is CheckStatus.PASS
-    assert result.details["nants_telescope"] == 37
-    assert result.details["vis_units"] == "Jy"
+    assert result.status is CheckStatus.WARN
+    assert "nbls" in result.message
+    assert "vis_units" in result.message
+
+
+def test_metadata_summary_warns_on_empty_header() -> None:
+    ctx = CheckContext(path=Path("dummy.uvh5"), header={})
+    result = checks_module.check_metadata_summary(ctx)
+    assert result.status is CheckStatus.WARN
 
 
 # ---------------------------------------------------------------------
@@ -305,6 +370,29 @@ def _write_minimal_uvh5_header(
         header["Npols"] = npols
         header["history"] = history
         header["vis_units"] = vis_units
+
+
+def test_read_uvh5_header_raises_for_missing_header_group(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "no_header_group.uvh5"
+    with h5py.File(path, "w") as handle:
+        handle.create_group("NotHeader")
+
+    with pytest.raises(KeyError):
+        read_uvh5_header(path)
+
+
+def test_read_uvh5_header_raises_for_malformed_scalar(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "malformed_scalar.uvh5"
+    with h5py.File(path, "w") as handle:
+        header = handle.create_group("Header")
+        header["Nants_telescope"] = "not-a-number"
+
+    with pytest.raises(ValueError):
+        read_uvh5_header(path)
 
 
 def test_read_uvh5_header_reads_expected_fields(tmp_path: Path) -> None:
@@ -341,14 +429,59 @@ def test_discover_uvh5_files_finds_files_in_directory(tmp_path: Path) -> None:
     sub.mkdir()
     (sub / "c.uvh5").touch()
 
-    found = discover_uvh5_files([tmp_path])
+    found, missing = discover_uvh5_files([tmp_path])
     assert {f.name for f in found} == {"a.uvh5", "b.uvh5", "c.uvh5"}
+    assert missing == []
 
 
 def test_discover_uvh5_files_accepts_direct_file(tmp_path: Path) -> None:
     f = tmp_path / "single.uvh5"
     f.touch()
-    assert discover_uvh5_files([f]) == [f]
+    found, missing = discover_uvh5_files([f])
+    assert found == [f]
+    assert missing == []
+
+
+def test_discover_uvh5_files_reports_missing_path(tmp_path: Path) -> None:
+    missing_path = tmp_path / "does_not_exist.uvh5"
+    found, missing = discover_uvh5_files([missing_path])
+    assert found == []
+    assert missing == [missing_path]
+
+
+def test_discover_uvh5_files_reports_mixed_valid_and_missing(
+    tmp_path: Path,
+) -> None:
+    present = tmp_path / "present.uvh5"
+    present.touch()
+    missing_path = tmp_path / "absent.uvh5"
+
+    found, missing = discover_uvh5_files([present, missing_path])
+    assert found == [present]
+    assert missing == [missing_path]
+
+
+def test_discover_uvh5_files_empty_directory_is_not_missing(
+    tmp_path: Path,
+) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    found, missing = discover_uvh5_files([empty_dir])
+    assert found == []
+    assert missing == []
+
+
+def test_discover_uvh5_files_deduplicates_overlapping_inputs(
+    tmp_path: Path,
+) -> None:
+    f = tmp_path / "dup.uvh5"
+    f.touch()
+
+    # Passed directly and also reachable via a directory scan.
+    found, missing = discover_uvh5_files([f, tmp_path, f])
+    assert found == [f]
+    assert missing == []
 
 
 def test_inspect_file_reports_error_for_unreadable_file(
@@ -359,6 +492,41 @@ def test_inspect_file_reports_error_for_unreadable_file(
 
     report = inspect_file(
         bad,
+        config_search_dirs=(),
+        expected_beam_type=None,
+        tiers=(CheckTier.FAST,),
+    )
+    assert report["error"] is not None
+    assert report["checks"] == []
+
+
+def test_inspect_file_reports_error_for_missing_header_group(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "no_header_group.uvh5"
+    with h5py.File(path, "w") as handle:
+        handle.create_group("NotHeader")
+
+    report = inspect_file(
+        path,
+        config_search_dirs=(),
+        expected_beam_type=None,
+        tiers=(CheckTier.FAST,),
+    )
+    assert report["error"] is not None
+    assert report["checks"] == []
+
+
+def test_inspect_file_reports_error_for_malformed_scalar(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "malformed_scalar.uvh5"
+    with h5py.File(path, "w") as handle:
+        header = handle.create_group("Header")
+        header["Nants_telescope"] = "not-a-number"
+
+    report = inspect_file(
+        path,
         config_search_dirs=(),
         expected_beam_type=None,
         tiers=(CheckTier.FAST,),
@@ -391,10 +559,12 @@ def test_main_end_to_end_flags_real_incident_pattern(
     assert code == 0  # advisory by default, even on FAIL
 
     payload = json.loads(capsys.readouterr().out)
-    assert len(payload) == 1
+    assert payload["missing_paths"] == []
+    reports = payload["reports"]
+    assert len(reports) == 1
     beam_check = next(
         c
-        for c in payload[0]["checks"]
+        for c in reports[0]["checks"]
         if c["check_id"] == "beam_type_consistency"
     )
     assert beam_check["status"] == "fail"
@@ -433,6 +603,65 @@ def test_main_returns_error_when_no_files_found(
     assert code == 2
     captured = capsys.readouterr()
     assert "no .uvh5 files found" in captured.err
+
+
+def test_main_returns_error_for_missing_path_only(
+    tmp_path: Path, capsys
+) -> None:
+    missing_path = tmp_path / "does_not_exist.uvh5"
+    code = main([str(missing_path)])
+    assert code == 3
+    captured = capsys.readouterr()
+    assert str(missing_path) in captured.err
+
+
+def test_main_processes_valid_files_despite_missing_path(
+    tmp_path: Path, capsys
+) -> None:
+    present = tmp_path / "present.uvh5"
+    _write_minimal_uvh5_header(present, history="no config references here")
+    missing_path = tmp_path / "absent.uvh5"
+
+    code = main([str(present), str(missing_path), "--json"])
+    assert code == 3
+
+    captured = capsys.readouterr()
+    assert str(missing_path) in captured.err
+
+    payload = json.loads(captured.out)
+    assert payload["missing_paths"] == [str(missing_path)]
+    assert len(payload["reports"]) == 1
+    assert payload["reports"][0]["path"] == str(present)
+    assert payload["reports"][0]["error"] is None
+
+
+def test_main_read_error_returns_nonzero_without_strict(
+    tmp_path: Path, capsys
+) -> None:
+    bad = tmp_path / "not_actually_hdf5.uvh5"
+    bad.write_text("not an hdf5 file", encoding="utf-8")
+
+    code = main([str(bad)])
+    assert code == 3  # I/O read failures are non-zero regardless of --strict
+    capsys.readouterr()
+
+
+def test_main_continues_past_read_errors_to_report_other_files(
+    tmp_path: Path, capsys
+) -> None:
+    bad = tmp_path / "not_actually_hdf5.uvh5"
+    bad.write_text("not an hdf5 file", encoding="utf-8")
+    good = tmp_path / "good.uvh5"
+    _write_minimal_uvh5_header(good, history="no config references here")
+
+    code = main([str(bad), str(good), "--json"])
+    assert code == 3
+
+    payload = json.loads(capsys.readouterr().out)
+    reports = {r["path"]: r for r in payload["reports"]}
+    assert reports[str(bad)]["error"] is not None
+    assert reports[str(good)]["error"] is None
+    assert reports[str(good)]["checks"]
 
 
 def test_build_parser_accepts_repeated_config_search_dir() -> None:

--- a/tests/test_data_preflight.py
+++ b/tests/test_data_preflight.py
@@ -320,9 +320,8 @@ def test_metadata_summary_reports_header_fields() -> None:
     assert result.details["vis_units"] == "Jy"
 
 
-def test_metadata_summary_warns_on_incomplete_header() -> None:
-    # A header missing several expected fields (e.g. an older or
-    # partially-written file) should not be reported as a clean PASS.
+def test_metadata_summary_fails_on_incomplete_header() -> None:
+    # A partially-written header must be rejected in strict mode.
     ctx = CheckContext(
         path=Path("dummy.uvh5"),
         header={
@@ -332,15 +331,15 @@ def test_metadata_summary_warns_on_incomplete_header() -> None:
         },
     )
     result = checks_module.check_metadata_summary(ctx)
-    assert result.status is CheckStatus.WARN
+    assert result.status is CheckStatus.FAIL
     assert "nbls" in result.message
     assert "vis_units" in result.message
 
 
-def test_metadata_summary_warns_on_empty_header() -> None:
+def test_metadata_summary_fails_on_empty_header() -> None:
     ctx = CheckContext(path=Path("dummy.uvh5"), header={})
     result = checks_module.check_metadata_summary(ctx)
-    assert result.status is CheckStatus.WARN
+    assert result.status is CheckStatus.FAIL
 
 
 # ---------------------------------------------------------------------
@@ -559,6 +558,7 @@ def test_main_end_to_end_flags_real_incident_pattern(
     assert code == 0  # advisory by default, even on FAIL
 
     payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == 1
     assert payload["missing_paths"] == []
     reports = payload["reports"]
     assert len(reports) == 1
@@ -605,6 +605,23 @@ def test_main_returns_error_when_no_files_found(
     assert "no .uvh5 files found" in captured.err
 
 
+def test_main_empty_directory_emits_json(tmp_path: Path, capsys) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    code = main([str(empty_dir), "--json"])
+
+    assert code == 2
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload == {
+        "schema_version": 1,
+        "missing_paths": [],
+        "reports": [],
+    }
+    assert "no .uvh5 files found" in captured.err
+
+
 def test_main_returns_error_for_missing_path_only(
     tmp_path: Path, capsys
 ) -> None:
@@ -612,6 +629,22 @@ def test_main_returns_error_for_missing_path_only(
     code = main([str(missing_path)])
     assert code == 3
     captured = capsys.readouterr()
+    assert str(missing_path) in captured.err
+
+
+def test_main_missing_path_only_emits_json(tmp_path: Path, capsys) -> None:
+    missing_path = tmp_path / "does_not_exist.uvh5"
+
+    code = main([str(missing_path), "--json"])
+
+    assert code == 3
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload == {
+        "schema_version": 1,
+        "missing_paths": [str(missing_path)],
+        "reports": [],
+    }
     assert str(missing_path) in captured.err
 
 
@@ -629,6 +662,7 @@ def test_main_processes_valid_files_despite_missing_path(
     assert str(missing_path) in captured.err
 
     payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
     assert payload["missing_paths"] == [str(missing_path)]
     assert len(payload["reports"]) == 1
     assert payload["reports"][0]["path"] == str(present)
@@ -662,6 +696,27 @@ def test_main_continues_past_read_errors_to_report_other_files(
     assert reports[str(bad)]["error"] is not None
     assert reports[str(good)]["error"] is None
     assert reports[str(good)]["checks"]
+
+
+def test_main_strict_fails_on_missing_required_header_field(
+    tmp_path: Path, capsys
+) -> None:
+    uvh5_path = tmp_path / "incomplete.uvh5"
+    _write_minimal_uvh5_header(uvh5_path, history="no config references here")
+    with h5py.File(uvh5_path, "a") as handle:
+        del handle["Header"]["Nbls"]
+
+    code = main([str(uvh5_path), "--strict", "--json"])
+
+    assert code == 1
+    payload = json.loads(capsys.readouterr().out)
+    metadata_check = next(
+        check
+        for check in payload["reports"][0]["checks"]
+        if check["check_id"] == "metadata_summary"
+    )
+    assert metadata_check["status"] == "fail"
+    assert "nbls" in metadata_check["message"]
 
 
 def test_build_parser_accepts_repeated_config_search_dir() -> None:


### PR DESCRIPTION
# Description

Adds `valska-data-preflight`, a command-line tool and check registry for
inexpensive checks on UVH5 files before they enter an analysis workflow.

The initial `beam_type_consistency` check compares beam-type claims in a
filename with the beam type declared by the telescope configuration cited in
the file's recorded history. This is a metadata and provenance consistency
check. It does not establish which beam generated the visibility data:
recorded history can be incomplete or stale, and a configuration found by
name need not be byte-identical to the file used during simulation.

The implementation:

- reads selected `/Header` fields directly with `h5py`, without loading full
  visibility arrays;
- rejects filenames that claim multiple recognised beam types;
- reports missing input paths and file-read failures distinctly and returns
  exit code 3 for those operational errors;
- treats missing required header fields as a failed check;
- remains advisory for scientific checks by default, while `--strict`
  returns exit code 1 when a readable file fails a check;
- de-duplicates files reached through overlapping input paths;
- provides versioned JSON output with `schema_version: 1`, including for
  missing-only and empty-directory outcomes; and
- documents usage, limitations, configuration discovery, exit codes and the
  machine-readable output contract.

A scan of 152 files under `UKSRC_val_mock_vis` on 2026-07-23 produced 25
PASS, 3 SKIP, 93 WARN and 31 FAIL results. These are results for that
directory tree on that date, not evidence that all provenance inconsistencies
have been identified.

The work is deliberately limited to fast, always-available checks. Reference
comparisons and delay-domain diagnostics are outside this change.

## Type of change
- New feature

## Checklist
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (`make python-test`: 229 passed)
- [x] Linting/formatting checks pass locally (`ruff`, `mypy` and pre-commit checks)
- [x] I have added or updated unit tests for my changes, where applicable (51 focused tests in `tests/test_data_preflight.py`)
- [x] I have updated relevant documentation (README, docs, docstrings, examples), where applicable and checked that the new documentation has rendered correctly in ReadTheDocs (clean local Sphinx build)
- [ ] I have linked any related issues and requested appropriate reviewers
